### PR TITLE
Add OpenSCAD model for Tuya tall sensor backplate

### DIFF
--- a/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad
+++ b/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad
@@ -1,0 +1,67 @@
+$fn = 64;
+
+// Thickness of the plate
+thickness = 1.5;
+
+// Overall plate dimensions
+plate_height = 69.5;
+plate_width  = 21.8;
+
+// Dimensions of the wider bottom section
+wide_width  = 25;
+wide_height = 12;
+
+// Small side tabs used as guides
+// These expand the width to 22.8 mm at three locations
+// along the height of the plate
+tab_width  = 22.8;
+tab_height = 5;
+// y positions for the centre of each tab relative to the
+// centre of the plate (positive is up)
+tab_positions = [23, 0, -23];
+
+// Screw hole measurements
+hole_spacing = 40;        // distance between hole centres
+hole_d      = 3;          // diameter of screw shaft
+csk_d       = 5.5;        // diameter of countersunk head
+csk_depth   = 1;          // depth of countersink
+
+// Distance from top edge to centre of first screw hole
+// (used to place both holes)
+top_to_first_hole = 13;
+
+module backplate2d() {
+    union() {
+        // main rectangle
+        square([plate_width, plate_height], center=true);
+        // wider bottom section
+        translate([0, -plate_height/2 + wide_height/2])
+            square([wide_width, wide_height], center=true);
+        // guiding tabs
+        for (y = tab_positions)
+            translate([0, y])
+                square([tab_width, tab_height], center=true);
+    }
+}
+
+module countersunk_hole() {
+    // screw shaft
+    cylinder(h = thickness, d = hole_d, center=false);
+    // countersink
+    translate([0,0,thickness - csk_depth])
+        cylinder(h = csk_depth, d1 = csk_d, d2 = hole_d, center=false);
+}
+
+// Create the 3D plate and remove the countersunk screw holes
+module backplate() {
+    difference() {
+        linear_extrude(thickness) backplate2d();
+        for (i = [0:1]) {
+            translate([0, plate_height/2 - top_to_first_hole - i*hole_spacing, 0])
+                countersunk_hole();
+        }
+    }
+}
+
+// Render the backplate
+backplate();

--- a/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.stl
+++ b/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.stl
@@ -1,0 +1,7982 @@
+solid OpenSCAD_Model
+  facet normal 0.514213 0.857662 -0
+    outer loop
+      vertex -0.707094 20.4271 0
+      vertex -0.833355 20.5028 0.5
+      vertex -0.707094 20.4271 0.5
+    endloop
+  endfacet
+  facet normal 0.514213 0.857662 0
+    outer loop
+      vertex -0.833355 20.5028 0.5
+      vertex -0.707094 20.4271 0
+      vertex -0.833355 20.5028 0
+    endloop
+  endfacet
+  facet normal 0.803153 -0.595773 0
+    outer loop
+      vertex -1.2472 22.5834 0.5
+      vertex -1.15952 22.7016 0
+      vertex -1.15952 22.7016 0.5
+    endloop
+  endfacet
+  facet normal 0.803153 -0.595773 0
+    outer loop
+      vertex -1.15952 22.7016 0
+      vertex -1.2472 22.5834 0.5
+      vertex -1.2472 22.5834 0
+    endloop
+  endfacet
+  facet normal -0.989174 -0.146746 0
+    outer loop
+      vertex 1.49278 21.897 0
+      vertex 1.47118 22.0426 0.5
+      vertex 1.47118 22.0426 0
+    endloop
+  endfacet
+  facet normal -0.989174 -0.146746 0
+    outer loop
+      vertex 1.47118 22.0426 0.5
+      vertex 1.49278 21.897 0
+      vertex 1.49278 21.897 0.5
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490565 0
+    outer loop
+      vertex 1.5 21.75 0
+      vertex 1.49278 21.897 0.5
+      vertex 1.49278 21.897 0
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490565 0
+    outer loop
+      vertex 1.49278 21.897 0.5
+      vertex 1.5 21.75 0
+      vertex 1.5 21.75 0.5
+    endloop
+  endfacet
+  facet normal -0.970031 -0.242983 0
+    outer loop
+      vertex 1.47118 22.0426 0
+      vertex 1.43541 22.1854 0.5
+      vertex 1.43541 22.1854 0
+    endloop
+  endfacet
+  facet normal -0.970031 -0.242983 0
+    outer loop
+      vertex 1.43541 22.1854 0.5
+      vertex 1.47118 22.0426 0
+      vertex 1.47118 22.0426 0.5
+    endloop
+  endfacet
+  facet normal -0.941548 0.336879 0
+    outer loop
+      vertex 1.38582 21.176 0
+      vertex 1.43541 21.3146 0.5
+      vertex 1.43541 21.3146 0
+    endloop
+  endfacet
+  facet normal -0.941548 0.336879 0
+    outer loop
+      vertex 1.43541 21.3146 0.5
+      vertex 1.38582 21.176 0
+      vertex 1.38582 21.176 0.5
+    endloop
+  endfacet
+  facet normal 0.595747 -0.803172 0
+    outer loop
+      vertex -0.95159 22.9095 0
+      vertex -0.833355 22.9972 0.5
+      vertex -0.95159 22.9095 0.5
+    endloop
+  endfacet
+  facet normal 0.595747 -0.803172 0
+    outer loop
+      vertex -0.833355 22.9972 0.5
+      vertex -0.95159 22.9095 0
+      vertex -0.833355 22.9972 0
+    endloop
+  endfacet
+  facet normal -0.941548 -0.336879 0
+    outer loop
+      vertex 1.43541 22.1854 0
+      vertex 1.38582 22.324 0.5
+      vertex 1.38582 22.324 0
+    endloop
+  endfacet
+  facet normal -0.941548 -0.336879 0
+    outer loop
+      vertex 1.38582 22.324 0.5
+      vertex 1.43541 22.1854 0
+      vertex 1.43541 22.1854 0.5
+    endloop
+  endfacet
+  facet normal 0.989174 -0.146746 0
+    outer loop
+      vertex -1.49278 21.897 0.5
+      vertex -1.47118 22.0426 0
+      vertex -1.47118 22.0426 0.5
+    endloop
+  endfacet
+  facet normal 0.989174 -0.146746 0
+    outer loop
+      vertex -1.47118 22.0426 0
+      vertex -1.49278 21.897 0.5
+      vertex -1.49278 21.897 0
+    endloop
+  endfacet
+  facet normal -0.671353 -0.741138 0
+    outer loop
+      vertex 0.95159 22.9095 0
+      vertex 1.06066 22.8107 0.5
+      vertex 0.95159 22.9095 0.5
+    endloop
+  endfacet
+  facet normal -0.671353 -0.741138 -0
+    outer loop
+      vertex 1.06066 22.8107 0.5
+      vertex 0.95159 22.9095 0
+      vertex 1.06066 22.8107 0
+    endloop
+  endfacet
+  facet normal 0.0489126 0.998803 -0
+    outer loop
+      vertex 0 20.25 0
+      vertex -0.147025 20.2572 0.5
+      vertex 0 20.25 0.5
+    endloop
+  endfacet
+  facet normal 0.0489126 0.998803 0
+    outer loop
+      vertex -0.147025 20.2572 0.5
+      vertex 0 20.25 0
+      vertex -0.147025 20.2572 0
+    endloop
+  endfacet
+  facet normal 0.941548 -0.336879 0
+    outer loop
+      vertex -1.43541 22.1854 0.5
+      vertex -1.38582 22.324 0
+      vertex -1.38582 22.324 0.5
+    endloop
+  endfacet
+  facet normal 0.941548 -0.336879 0
+    outer loop
+      vertex -1.38582 22.324 0
+      vertex -1.43541 22.1854 0.5
+      vertex -1.43541 22.1854 0
+    endloop
+  endfacet
+  facet normal -0.0489126 -0.998803 0
+    outer loop
+      vertex 0 23.25 0
+      vertex 0.147025 23.2428 0.5
+      vertex 0 23.25 0.5
+    endloop
+  endfacet
+  facet normal -0.0489126 -0.998803 -0
+    outer loop
+      vertex 0.147025 23.2428 0.5
+      vertex 0 23.25 0
+      vertex 0.147025 23.2428 0
+    endloop
+  endfacet
+  facet normal 0.857792 -0.513996 0
+    outer loop
+      vertex -1.32288 22.4571 0.5
+      vertex -1.2472 22.5834 0
+      vertex -1.2472 22.5834 0.5
+    endloop
+  endfacet
+  facet normal 0.857792 -0.513996 0
+    outer loop
+      vertex -1.2472 22.5834 0
+      vertex -1.32288 22.4571 0.5
+      vertex -1.32288 22.4571 0
+    endloop
+  endfacet
+  facet normal 0.336945 -0.941524 0
+    outer loop
+      vertex -0.574024 23.1358 0
+      vertex -0.435427 23.1854 0.5
+      vertex -0.574024 23.1358 0.5
+    endloop
+  endfacet
+  facet normal 0.336945 -0.941524 0
+    outer loop
+      vertex -0.435427 23.1854 0.5
+      vertex -0.574024 23.1358 0
+      vertex -0.435427 23.1854 0
+    endloop
+  endfacet
+  facet normal 0.146736 -0.989176 0
+    outer loop
+      vertex -0.292635 23.2212 0
+      vertex -0.147025 23.2428 0.5
+      vertex -0.292635 23.2212 0.5
+    endloop
+  endfacet
+  facet normal 0.146736 -0.989176 0
+    outer loop
+      vertex -0.147025 23.2428 0.5
+      vertex -0.292635 23.2212 0
+      vertex -0.147025 23.2428 0
+    endloop
+  endfacet
+  facet normal -0.427347 -0.904088 0
+    outer loop
+      vertex 0.574024 23.1358 0
+      vertex 0.707094 23.0729 0.5
+      vertex 0.574024 23.1358 0.5
+    endloop
+  endfacet
+  facet normal -0.427347 -0.904088 -0
+    outer loop
+      vertex 0.707094 23.0729 0.5
+      vertex 0.574024 23.1358 0
+      vertex 0.707094 23.0729 0
+    endloop
+  endfacet
+  facet normal 0.671353 0.741138 -0
+    outer loop
+      vertex -0.95159 20.5905 0
+      vertex -1.06066 20.6893 0.5
+      vertex -0.95159 20.5905 0.5
+    endloop
+  endfacet
+  facet normal 0.671353 0.741138 0
+    outer loop
+      vertex -1.06066 20.6893 0.5
+      vertex -0.95159 20.5905 0
+      vertex -1.06066 20.6893 0
+    endloop
+  endfacet
+  facet normal -0.146736 0.989176 0
+    outer loop
+      vertex 0.292635 20.2788 0
+      vertex 0.147025 20.2572 0.5
+      vertex 0.292635 20.2788 0.5
+    endloop
+  endfacet
+  facet normal -0.146736 0.989176 0
+    outer loop
+      vertex 0.147025 20.2572 0.5
+      vertex 0.292635 20.2788 0
+      vertex 0.147025 20.2572 0
+    endloop
+  endfacet
+  facet normal -0.243188 -0.969979 0
+    outer loop
+      vertex 0.292635 23.2212 0
+      vertex 0.435427 23.1854 0.5
+      vertex 0.292635 23.2212 0.5
+    endloop
+  endfacet
+  facet normal -0.243188 -0.969979 -0
+    outer loop
+      vertex 0.435427 23.1854 0.5
+      vertex 0.292635 23.2212 0
+      vertex 0.435427 23.1854 0
+    endloop
+  endfacet
+  facet normal -0.803153 0.595773 0
+    outer loop
+      vertex 1.15952 20.7984 0
+      vertex 1.2472 20.9166 0.5
+      vertex 1.2472 20.9166 0
+    endloop
+  endfacet
+  facet normal -0.803153 0.595773 0
+    outer loop
+      vertex 1.2472 20.9166 0.5
+      vertex 1.15952 20.7984 0
+      vertex 1.15952 20.7984 0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.4 20.5 0
+      vertex -10.9 25.5 0
+      vertex -10.9 20.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -11.4 20.5 0
+      vertex -11.4 25.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.4 -2.5 0
+      vertex -10.9 2.5 0
+      vertex -10.9 -2.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.9 2.5 0
+      vertex -11.4 -2.5 0
+      vertex -11.4 2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.38582 -17.676 0
+      vertex 10.9 -20.5 0
+      vertex 1.43541 -17.8146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.49278 21.603 0
+      vertex 1.5 21.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.32288 -17.5429 0
+      vertex 10.9 -20.5 0
+      vertex 1.38582 -17.676 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.47118 21.4574 0
+      vertex 1.49278 21.603 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2472 -17.4166 0
+      vertex 10.9 -20.5 0
+      vertex 1.32288 -17.5429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.43541 21.3146 0
+      vertex 1.47118 21.4574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.15952 -17.2984 0
+      vertex 10.9 -20.5 0
+      vertex 1.2472 -17.4166 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.38582 21.176 0
+      vertex 1.43541 21.3146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.15952 -17.2984 0
+      vertex 10.9 -2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.32288 21.0429 0
+      vertex 1.38582 21.176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.06066 -17.1893 0
+      vertex 10.9 -2.5 0
+      vertex 1.15952 -17.2984 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.2472 20.9166 0
+      vertex 1.32288 21.0429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.95159 -17.0905 0
+      vertex 10.9 -2.5 0
+      vertex 1.06066 -17.1893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.15952 20.7984 0
+      vertex 1.2472 20.9166 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.833355 -17.0028 0
+      vertex 10.9 -2.5 0
+      vertex 0.95159 -17.0905 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.06066 20.6893 0
+      vertex 1.15952 20.7984 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.707094 -16.9271 0
+      vertex 10.9 -2.5 0
+      vertex 0.833355 -17.0028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.95159 20.5905 0
+      vertex 1.06066 20.6893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.574024 -16.8642 0
+      vertex 10.9 -2.5 0
+      vertex 0.707094 -16.9271 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.833355 20.5028 0
+      vertex 0.95159 20.5905 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.435427 -16.8146 0
+      vertex 10.9 -2.5 0
+      vertex 0.574024 -16.8642 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.707094 20.4271 0
+      vertex 0.833355 20.5028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.292635 -16.7788 0
+      vertex 10.9 -2.5 0
+      vertex 0.435427 -16.8146 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 0 20.25 0
+      vertex 10.9 2.5 0
+      vertex -10.9 2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.147025 -16.7572 0
+      vertex 10.9 -2.5 0
+      vertex 0.292635 -16.7788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.574024 20.3642 0
+      vertex 0.707094 20.4271 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -16.75 0
+      vertex 10.9 -2.5 0
+      vertex 0.147025 -16.7572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.435427 20.3146 0
+      vertex 0.574024 20.3642 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -2.5 0
+      vertex -10.9 -2.5 0
+      vertex 10.9 2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.292635 20.2788 0
+      vertex 0.435427 20.3146 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9 -2.5 0
+      vertex 0 -16.75 0
+      vertex -10.9 -2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0.147025 20.2572 0
+      vertex 0.292635 20.2788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex 0 -16.75 0
+      vertex -0.147025 -16.7572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 0 20.25 0
+      vertex 0.147025 20.2572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.147025 -16.7572 0
+      vertex -0.292635 -16.7788 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0 20.25 0
+      vertex -10.9 2.5 0
+      vertex -0.147025 20.2572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.292635 -16.7788 0
+      vertex -0.435427 -16.8146 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.147025 20.2572 0
+      vertex -10.9 2.5 0
+      vertex -0.292635 20.2788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.435427 -16.8146 0
+      vertex -0.574024 -16.8642 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.292635 20.2788 0
+      vertex -10.9 2.5 0
+      vertex -0.435427 20.3146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.574024 -16.8642 0
+      vertex -0.707094 -16.9271 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.435427 20.3146 0
+      vertex -10.9 2.5 0
+      vertex -0.574024 20.3642 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.707094 -16.9271 0
+      vertex -0.833355 -17.0028 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.574024 20.3642 0
+      vertex -10.9 2.5 0
+      vertex -0.707094 20.4271 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.833355 -17.0028 0
+      vertex -0.95159 -17.0905 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 20.5 0
+      vertex -0.707094 20.4271 0
+      vertex -10.9 2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -0.95159 -17.0905 0
+      vertex -1.06066 -17.1893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.707094 20.4271 0
+      vertex -10.9 20.5 0
+      vertex -0.833355 20.5028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -2.5 0
+      vertex -1.06066 -17.1893 0
+      vertex -1.15952 -17.2984 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.833355 20.5028 0
+      vertex -10.9 20.5 0
+      vertex -0.95159 20.5905 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.15952 -17.2984 0
+      vertex -1.2472 -17.4166 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.95159 20.5905 0
+      vertex -10.9 20.5 0
+      vertex -1.06066 20.6893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.2472 -17.4166 0
+      vertex -1.32288 -17.5429 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.06066 20.6893 0
+      vertex -10.9 20.5 0
+      vertex -1.15952 20.7984 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.32288 -17.5429 0
+      vertex -1.38582 -17.676 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.15952 20.7984 0
+      vertex -10.9 20.5 0
+      vertex -1.2472 20.9166 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.38582 -17.676 0
+      vertex -1.43541 -17.8146 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.2472 20.9166 0
+      vertex -10.9 20.5 0
+      vertex -1.32288 21.0429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.43541 -17.8146 0
+      vertex -1.47118 -17.9574 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.32288 21.0429 0
+      vertex -10.9 20.5 0
+      vertex -1.38582 21.176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.47118 -17.9574 0
+      vertex -1.49278 -18.103 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.38582 21.176 0
+      vertex -10.9 20.5 0
+      vertex -1.43541 21.3146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -1.49278 -18.103 0
+      vertex -1.5 -18.25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.43541 21.3146 0
+      vertex -10.9 20.5 0
+      vertex -1.47118 21.4574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.5 -34.75 0
+      vertex 11.4 -22.75 0
+      vertex 12.5 -22.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.4 -22.75 0
+      vertex 10.9 -20.5 0
+      vertex 11.4 -20.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.435427 -19.6854 0
+      vertex 11.4 -22.75 0
+      vertex 12.5 -34.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49278 -18.103 0
+      vertex 10.9 -20.5 0
+      vertex 1.5 -18.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47118 -17.9574 0
+      vertex 10.9 -20.5 0
+      vertex 1.49278 -18.103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.43541 -17.8146 0
+      vertex 10.9 -20.5 0
+      vertex 1.47118 -17.9574 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49278 21.897 0
+      vertex 10.9 20.5 0
+      vertex 1.5 21.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex 1.5 21.75 0
+      vertex 10.9 20.5 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 0.833355 -19.4972 0
+      vertex 11.4 -22.75 0
+      vertex 0.707094 -19.5729 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.49278 -18.397 0
+      vertex 1.5 -18.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.47118 -18.5426 0
+      vertex 1.49278 -18.397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.43541 -18.6854 0
+      vertex 1.47118 -18.5426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.38582 -18.824 0
+      vertex 1.43541 -18.6854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.32288 -18.9571 0
+      vertex 1.38582 -18.824 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.2472 -19.0834 0
+      vertex 1.32288 -18.9571 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -20.5 0
+      vertex 1.15952 -19.2016 0
+      vertex 1.2472 -19.0834 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.4 -22.75 0
+      vertex 1.15952 -19.2016 0
+      vertex 10.9 -20.5 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 1.15952 -19.2016 0
+      vertex 11.4 -22.75 0
+      vertex 1.06066 -19.3107 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 1.06066 -19.3107 0
+      vertex 11.4 -22.75 0
+      vertex 0.95159 -19.4095 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 0.95159 -19.4095 0
+      vertex 11.4 -22.75 0
+      vertex 0.833355 -19.4972 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.4 -22.75 0
+      vertex 0.574024 -19.6358 0
+      vertex 0.707094 -19.5729 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.4 -22.75 0
+      vertex 0.435427 -19.6854 0
+      vertex 0.574024 -19.6358 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.5 -34.75 0
+      vertex 0.292635 -19.7212 0
+      vertex 0.435427 -19.6854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.5 -34.75 0
+      vertex 0.147025 -19.7428 0
+      vertex 0.292635 -19.7212 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.5 -34.75 0
+      vertex 0 -19.75 0
+      vertex 0.147025 -19.7428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5 -34.75 0
+      vertex 0 -19.75 0
+      vertex 12.5 -34.75 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0 -19.75 0
+      vertex -12.5 -34.75 0
+      vertex -0.147025 -19.7428 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.147025 -19.7428 0
+      vertex -12.5 -34.75 0
+      vertex -0.292635 -19.7212 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.292635 -19.7212 0
+      vertex -12.5 -34.75 0
+      vertex -0.435427 -19.6854 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -11.4 -22.75 0
+      vertex -0.435427 -19.6854 0
+      vertex -12.5 -34.75 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.435427 -19.6854 0
+      vertex -11.4 -22.75 0
+      vertex -0.574024 -19.6358 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.574024 -19.6358 0
+      vertex -11.4 -22.75 0
+      vertex -0.707094 -19.5729 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.707094 -19.5729 0
+      vertex -11.4 -22.75 0
+      vertex -0.833355 -19.4972 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.833355 -19.4972 0
+      vertex -11.4 -22.75 0
+      vertex -0.95159 -19.4095 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.15952 -17.2984 0
+      vertex -10.9 -20.5 0
+      vertex -10.9 -2.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49278 -18.397 0
+      vertex -10.9 -20.5 0
+      vertex -1.5 -18.25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.47118 -18.5426 0
+      vertex -10.9 -20.5 0
+      vertex -1.49278 -18.397 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.43541 -18.6854 0
+      vertex -10.9 -20.5 0
+      vertex -1.47118 -18.5426 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.38582 -18.824 0
+      vertex -10.9 -20.5 0
+      vertex -1.43541 -18.6854 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.32288 -18.9571 0
+      vertex -10.9 -20.5 0
+      vertex -1.38582 -18.824 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.2472 -19.0834 0
+      vertex -10.9 -20.5 0
+      vertex -1.32288 -18.9571 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.15952 -19.2016 0
+      vertex -10.9 -20.5 0
+      vertex -1.2472 -19.0834 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.95159 -19.4095 0
+      vertex -11.4 -22.75 0
+      vertex -1.06066 -19.3107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.15952 -19.2016 0
+      vertex -11.4 -22.75 0
+      vertex -10.9 -20.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.06066 -19.3107 0
+      vertex -11.4 -22.75 0
+      vertex -1.15952 -19.2016 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.4 -22.75 0
+      vertex -12.5 -34.75 0
+      vertex -12.5 -22.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 -2.5 0
+      vertex 11.4 2.5 0
+      vertex 11.4 -2.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.4 2.5 0
+      vertex 10.9 -2.5 0
+      vertex 10.9 2.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 20.5 0
+      vertex 11.4 25.5 0
+      vertex 11.4 20.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.4 25.5 0
+      vertex 10.9 20.5 0
+      vertex 10.9 25.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47118 22.0426 0
+      vertex 10.9 20.5 0
+      vertex 1.49278 21.897 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9 20.5 0
+      vertex 1.47118 22.0426 0
+      vertex 10.9 25.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.43541 22.1854 0
+      vertex 10.9 25.5 0
+      vertex 1.47118 22.0426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.38582 22.324 0
+      vertex 10.9 25.5 0
+      vertex 1.43541 22.1854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.32288 22.4571 0
+      vertex 10.9 25.5 0
+      vertex 1.38582 22.324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2472 22.5834 0
+      vertex 10.9 25.5 0
+      vertex 1.32288 22.4571 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.15952 22.7016 0
+      vertex 10.9 25.5 0
+      vertex 1.2472 22.5834 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.06066 22.8107 0
+      vertex 10.9 25.5 0
+      vertex 1.15952 22.7016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.95159 22.9095 0
+      vertex 10.9 25.5 0
+      vertex 1.06066 22.8107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.833355 22.9972 0
+      vertex 10.9 25.5 0
+      vertex 0.95159 22.9095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.707094 23.0729 0
+      vertex 10.9 25.5 0
+      vertex 0.833355 22.9972 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9 25.5 0
+      vertex 0.707094 23.0729 0
+      vertex 10.9 34.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.574024 23.1358 0
+      vertex 10.9 34.75 0
+      vertex 0.707094 23.0729 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.435427 23.1854 0
+      vertex 10.9 34.75 0
+      vertex 0.574024 23.1358 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.292635 23.2212 0
+      vertex 10.9 34.75 0
+      vertex 0.435427 23.1854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.147025 23.2428 0
+      vertex 10.9 34.75 0
+      vertex 0.292635 23.2212 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 23.25 0
+      vertex 10.9 34.75 0
+      vertex 0.147025 23.2428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 34.75 0
+      vertex 0 23.25 0
+      vertex -0.147025 23.2428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 34.75 0
+      vertex -0.147025 23.2428 0
+      vertex -0.292635 23.2212 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 34.75 0
+      vertex -0.292635 23.2212 0
+      vertex -0.435427 23.1854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 34.75 0
+      vertex -0.435427 23.1854 0
+      vertex -0.574024 23.1358 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 34.75 0
+      vertex -0.574024 23.1358 0
+      vertex -0.707094 23.0729 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -0.707094 23.0729 0
+      vertex -0.833355 22.9972 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -0.833355 22.9972 0
+      vertex -0.95159 22.9095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -0.95159 22.9095 0
+      vertex -1.06066 22.8107 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9 2.5 0
+      vertex -10.9 -2.5 0
+      vertex -10.9 2.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.47118 21.4574 0
+      vertex -10.9 20.5 0
+      vertex -1.49278 21.603 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49278 21.603 0
+      vertex -10.9 20.5 0
+      vertex -1.5 21.75 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.5 21.75 0
+      vertex -10.9 20.5 0
+      vertex -1.49278 21.897 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49278 21.897 0
+      vertex -10.9 20.5 0
+      vertex -1.47118 22.0426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -1.47118 22.0426 0
+      vertex -10.9 20.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.47118 22.0426 0
+      vertex -10.9 25.5 0
+      vertex -1.43541 22.1854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.43541 22.1854 0
+      vertex -10.9 25.5 0
+      vertex -1.38582 22.324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.38582 22.324 0
+      vertex -10.9 25.5 0
+      vertex -1.32288 22.4571 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.32288 22.4571 0
+      vertex -10.9 25.5 0
+      vertex -1.2472 22.5834 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2472 22.5834 0
+      vertex -10.9 25.5 0
+      vertex -1.15952 22.7016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.15952 22.7016 0
+      vertex -10.9 25.5 0
+      vertex -1.06066 22.8107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.707094 23.0729 0
+      vertex -10.9 25.5 0
+      vertex -10.9 34.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 23.25 0
+      vertex -10.9 34.75 0
+      vertex 10.9 34.75 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -11.4 -22.75 0
+      vertex -11.4 -20.5 0
+    endloop
+  endfacet
+  facet normal -0.595747 0.803172 0
+    outer loop
+      vertex 0.95159 20.5905 0
+      vertex 0.833355 20.5028 0.5
+      vertex 0.95159 20.5905 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 0.803172 0
+    outer loop
+      vertex 0.833355 20.5028 0.5
+      vertex 0.95159 20.5905 0
+      vertex 0.833355 20.5028 0
+    endloop
+  endfacet
+  facet normal 0.514213 -0.857662 0
+    outer loop
+      vertex -0.833355 22.9972 0
+      vertex -0.707094 23.0729 0.5
+      vertex -0.833355 22.9972 0.5
+    endloop
+  endfacet
+  facet normal 0.514213 -0.857662 0
+    outer loop
+      vertex -0.707094 23.0729 0.5
+      vertex -0.833355 22.9972 0
+      vertex -0.707094 23.0729 0
+    endloop
+  endfacet
+  facet normal -0.989174 0.146746 0
+    outer loop
+      vertex 1.47118 21.4574 0
+      vertex 1.49278 21.603 0.5
+      vertex 1.49278 21.603 0
+    endloop
+  endfacet
+  facet normal -0.989174 0.146746 0
+    outer loop
+      vertex 1.49278 21.603 0.5
+      vertex 1.47118 21.4574 0
+      vertex 1.47118 21.4574 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 -0.803172 0
+    outer loop
+      vertex 0.833355 22.9972 0
+      vertex 0.95159 22.9095 0.5
+      vertex 0.833355 22.9972 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 -0.803172 -0
+    outer loop
+      vertex 0.95159 22.9095 0.5
+      vertex 0.833355 22.9972 0
+      vertex 0.95159 22.9095 0
+    endloop
+  endfacet
+  facet normal -0.970031 0.242983 0
+    outer loop
+      vertex 1.43541 21.3146 0
+      vertex 1.47118 21.4574 0.5
+      vertex 1.47118 21.4574 0
+    endloop
+  endfacet
+  facet normal -0.970031 0.242983 0
+    outer loop
+      vertex 1.47118 21.4574 0.5
+      vertex 1.43541 21.3146 0
+      vertex 1.43541 21.3146 0.5
+    endloop
+  endfacet
+  facet normal -0.803153 -0.595773 0
+    outer loop
+      vertex 1.2472 22.5834 0
+      vertex 1.15952 22.7016 0.5
+      vertex 1.15952 22.7016 0
+    endloop
+  endfacet
+  facet normal -0.803153 -0.595773 0
+    outer loop
+      vertex 1.15952 22.7016 0.5
+      vertex 1.2472 22.5834 0
+      vertex 1.2472 22.5834 0.5
+    endloop
+  endfacet
+  facet normal -0.243188 0.969979 0
+    outer loop
+      vertex 0.435427 20.3146 0
+      vertex 0.292635 20.2788 0.5
+      vertex 0.435427 20.3146 0.5
+    endloop
+  endfacet
+  facet normal -0.243188 0.969979 0
+    outer loop
+      vertex 0.292635 20.2788 0.5
+      vertex 0.435427 20.3146 0
+      vertex 0.292635 20.2788 0
+    endloop
+  endfacet
+  facet normal -0.514213 -0.857662 0
+    outer loop
+      vertex 0.707094 23.0729 0
+      vertex 0.833355 22.9972 0.5
+      vertex 0.707094 23.0729 0.5
+    endloop
+  endfacet
+  facet normal -0.514213 -0.857662 -0
+    outer loop
+      vertex 0.833355 22.9972 0.5
+      vertex 0.707094 23.0729 0
+      vertex 0.833355 22.9972 0
+    endloop
+  endfacet
+  facet normal 0.243188 0.969979 -0
+    outer loop
+      vertex -0.292635 20.2788 0
+      vertex -0.435427 20.3146 0.5
+      vertex -0.292635 20.2788 0.5
+    endloop
+  endfacet
+  facet normal 0.243188 0.969979 0
+    outer loop
+      vertex -0.435427 20.3146 0.5
+      vertex -0.292635 20.2788 0
+      vertex -0.435427 20.3146 0
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490565 0
+    outer loop
+      vertex 1.49278 21.603 0
+      vertex 1.5 21.75 0.5
+      vertex 1.5 21.75 0
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490565 0
+    outer loop
+      vertex 1.5 21.75 0.5
+      vertex 1.49278 21.603 0
+      vertex 1.49278 21.603 0.5
+    endloop
+  endfacet
+  facet normal -0.857792 -0.513996 0
+    outer loop
+      vertex 1.32288 22.4571 0
+      vertex 1.2472 22.5834 0.5
+      vertex 1.2472 22.5834 0
+    endloop
+  endfacet
+  facet normal -0.857792 -0.513996 0
+    outer loop
+      vertex 1.2472 22.5834 0.5
+      vertex 1.32288 22.4571 0
+      vertex 1.32288 22.4571 0.5
+    endloop
+  endfacet
+  facet normal -0.741027 -0.671475 0
+    outer loop
+      vertex 1.15952 22.7016 0
+      vertex 1.06066 22.8107 0.5
+      vertex 1.06066 22.8107 0
+    endloop
+  endfacet
+  facet normal -0.741027 -0.671475 0
+    outer loop
+      vertex 1.06066 22.8107 0.5
+      vertex 1.15952 22.7016 0
+      vertex 1.15952 22.7016 0.5
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490565 0
+    outer loop
+      vertex -1.5 21.75 0.5
+      vertex -1.49278 21.897 0
+      vertex -1.49278 21.897 0.5
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490565 0
+    outer loop
+      vertex -1.49278 21.897 0
+      vertex -1.5 21.75 0.5
+      vertex -1.5 21.75 0
+    endloop
+  endfacet
+  facet normal -0.146736 -0.989176 0
+    outer loop
+      vertex 0.147025 23.2428 0
+      vertex 0.292635 23.2212 0.5
+      vertex 0.147025 23.2428 0.5
+    endloop
+  endfacet
+  facet normal -0.146736 -0.989176 -0
+    outer loop
+      vertex 0.292635 23.2212 0.5
+      vertex 0.147025 23.2428 0
+      vertex 0.292635 23.2212 0
+    endloop
+  endfacet
+  facet normal -0.336945 0.941524 0
+    outer loop
+      vertex 0.574024 20.3642 0
+      vertex 0.435427 20.3146 0.5
+      vertex 0.574024 20.3642 0.5
+    endloop
+  endfacet
+  facet normal -0.336945 0.941524 0
+    outer loop
+      vertex 0.435427 20.3146 0.5
+      vertex 0.574024 20.3642 0
+      vertex 0.435427 20.3146 0
+    endloop
+  endfacet
+  facet normal -0.0489126 0.998803 0
+    outer loop
+      vertex 0.147025 20.2572 0
+      vertex 0 20.25 0.5
+      vertex 0.147025 20.2572 0.5
+    endloop
+  endfacet
+  facet normal -0.0489126 0.998803 0
+    outer loop
+      vertex 0 20.25 0.5
+      vertex 0.147025 20.2572 0
+      vertex 0 20.25 0
+    endloop
+  endfacet
+  facet normal -0.857792 0.513996 0
+    outer loop
+      vertex 1.2472 20.9166 0
+      vertex 1.32288 21.0429 0.5
+      vertex 1.32288 21.0429 0
+    endloop
+  endfacet
+  facet normal -0.857792 0.513996 0
+    outer loop
+      vertex 1.32288 21.0429 0.5
+      vertex 1.2472 20.9166 0
+      vertex 1.2472 20.9166 0.5
+    endloop
+  endfacet
+  facet normal 0.857792 0.513996 0
+    outer loop
+      vertex -1.2472 20.9166 0.5
+      vertex -1.32288 21.0429 0
+      vertex -1.32288 21.0429 0.5
+    endloop
+  endfacet
+  facet normal 0.857792 0.513996 0
+    outer loop
+      vertex -1.32288 21.0429 0
+      vertex -1.2472 20.9166 0.5
+      vertex -1.2472 20.9166 0
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490565 0
+    outer loop
+      vertex -1.49278 21.603 0.5
+      vertex -1.5 21.75 0
+      vertex -1.5 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490565 0
+    outer loop
+      vertex -1.5 21.75 0
+      vertex -1.49278 21.603 0.5
+      vertex -1.49278 21.603 0
+    endloop
+  endfacet
+  facet normal 0.741027 -0.671475 0
+    outer loop
+      vertex -1.15952 22.7016 0.5
+      vertex -1.06066 22.8107 0
+      vertex -1.06066 22.8107 0.5
+    endloop
+  endfacet
+  facet normal 0.741027 -0.671475 0
+    outer loop
+      vertex -1.06066 22.8107 0
+      vertex -1.15952 22.7016 0.5
+      vertex -1.15952 22.7016 0
+    endloop
+  endfacet
+  facet normal -0.741027 0.671475 0
+    outer loop
+      vertex 1.06066 20.6893 0
+      vertex 1.15952 20.7984 0.5
+      vertex 1.15952 20.7984 0
+    endloop
+  endfacet
+  facet normal -0.741027 0.671475 0
+    outer loop
+      vertex 1.15952 20.7984 0.5
+      vertex 1.06066 20.6893 0
+      vertex 1.06066 20.6893 0.5
+    endloop
+  endfacet
+  facet normal 0.0489126 -0.998803 0
+    outer loop
+      vertex -0.147025 23.2428 0
+      vertex 0 23.25 0.5
+      vertex -0.147025 23.2428 0.5
+    endloop
+  endfacet
+  facet normal 0.0489126 -0.998803 0
+    outer loop
+      vertex 0 23.25 0.5
+      vertex -0.147025 23.2428 0
+      vertex 0 23.25 0
+    endloop
+  endfacet
+  facet normal -0.90402 -0.427491 0
+    outer loop
+      vertex 1.38582 22.324 0
+      vertex 1.32288 22.4571 0.5
+      vertex 1.32288 22.4571 0
+    endloop
+  endfacet
+  facet normal -0.90402 -0.427491 0
+    outer loop
+      vertex 1.32288 22.4571 0.5
+      vertex 1.38582 22.324 0
+      vertex 1.38582 22.324 0.5
+    endloop
+  endfacet
+  facet normal 0.90402 -0.427491 0
+    outer loop
+      vertex -1.38582 22.324 0.5
+      vertex -1.32288 22.4571 0
+      vertex -1.32288 22.4571 0.5
+    endloop
+  endfacet
+  facet normal 0.90402 -0.427491 0
+    outer loop
+      vertex -1.32288 22.4571 0
+      vertex -1.38582 22.324 0.5
+      vertex -1.38582 22.324 0
+    endloop
+  endfacet
+  facet normal 0.671353 -0.741138 0
+    outer loop
+      vertex -1.06066 22.8107 0
+      vertex -0.95159 22.9095 0.5
+      vertex -1.06066 22.8107 0.5
+    endloop
+  endfacet
+  facet normal 0.671353 -0.741138 0
+    outer loop
+      vertex -0.95159 22.9095 0.5
+      vertex -1.06066 22.8107 0
+      vertex -0.95159 22.9095 0
+    endloop
+  endfacet
+  facet normal -0.336945 -0.941524 0
+    outer loop
+      vertex 0.435427 23.1854 0
+      vertex 0.574024 23.1358 0.5
+      vertex 0.435427 23.1854 0.5
+    endloop
+  endfacet
+  facet normal -0.336945 -0.941524 -0
+    outer loop
+      vertex 0.574024 23.1358 0.5
+      vertex 0.435427 23.1854 0
+      vertex 0.574024 23.1358 0
+    endloop
+  endfacet
+  facet normal -0.427347 0.904088 0
+    outer loop
+      vertex 0.707094 20.4271 0
+      vertex 0.574024 20.3642 0.5
+      vertex 0.707094 20.4271 0.5
+    endloop
+  endfacet
+  facet normal -0.427347 0.904088 0
+    outer loop
+      vertex 0.574024 20.3642 0.5
+      vertex 0.707094 20.4271 0
+      vertex 0.574024 20.3642 0
+    endloop
+  endfacet
+  facet normal 0.243188 -0.969979 0
+    outer loop
+      vertex -0.435427 23.1854 0
+      vertex -0.292635 23.2212 0.5
+      vertex -0.435427 23.1854 0.5
+    endloop
+  endfacet
+  facet normal 0.243188 -0.969979 0
+    outer loop
+      vertex -0.292635 23.2212 0.5
+      vertex -0.435427 23.1854 0
+      vertex -0.292635 23.2212 0
+    endloop
+  endfacet
+  facet normal 0.970031 0.242983 0
+    outer loop
+      vertex -1.43541 21.3146 0.5
+      vertex -1.47118 21.4574 0
+      vertex -1.47118 21.4574 0.5
+    endloop
+  endfacet
+  facet normal 0.970031 0.242983 0
+    outer loop
+      vertex -1.47118 21.4574 0
+      vertex -1.43541 21.3146 0.5
+      vertex -1.43541 21.3146 0
+    endloop
+  endfacet
+  facet normal 0.970031 -0.242983 0
+    outer loop
+      vertex -1.47118 22.0426 0.5
+      vertex -1.43541 22.1854 0
+      vertex -1.43541 22.1854 0.5
+    endloop
+  endfacet
+  facet normal 0.970031 -0.242983 0
+    outer loop
+      vertex -1.43541 22.1854 0
+      vertex -1.47118 22.0426 0.5
+      vertex -1.47118 22.0426 0
+    endloop
+  endfacet
+  facet normal 0.941548 0.336879 0
+    outer loop
+      vertex -1.38582 21.176 0.5
+      vertex -1.43541 21.3146 0
+      vertex -1.43541 21.3146 0.5
+    endloop
+  endfacet
+  facet normal 0.941548 0.336879 0
+    outer loop
+      vertex -1.43541 21.3146 0
+      vertex -1.38582 21.176 0.5
+      vertex -1.38582 21.176 0
+    endloop
+  endfacet
+  facet normal 0.741027 0.671475 0
+    outer loop
+      vertex -1.06066 20.6893 0.5
+      vertex -1.15952 20.7984 0
+      vertex -1.15952 20.7984 0.5
+    endloop
+  endfacet
+  facet normal 0.741027 0.671475 0
+    outer loop
+      vertex -1.15952 20.7984 0
+      vertex -1.06066 20.6893 0.5
+      vertex -1.06066 20.6893 0
+    endloop
+  endfacet
+  facet normal 0.803153 0.595773 0
+    outer loop
+      vertex -1.15952 20.7984 0.5
+      vertex -1.2472 20.9166 0
+      vertex -1.2472 20.9166 0.5
+    endloop
+  endfacet
+  facet normal 0.803153 0.595773 0
+    outer loop
+      vertex -1.2472 20.9166 0
+      vertex -1.15952 20.7984 0.5
+      vertex -1.15952 20.7984 0
+    endloop
+  endfacet
+  facet normal 0.427347 0.904088 -0
+    outer loop
+      vertex -0.574024 20.3642 0
+      vertex -0.707094 20.4271 0.5
+      vertex -0.574024 20.3642 0.5
+    endloop
+  endfacet
+  facet normal 0.427347 0.904088 0
+    outer loop
+      vertex -0.707094 20.4271 0.5
+      vertex -0.574024 20.3642 0
+      vertex -0.707094 20.4271 0
+    endloop
+  endfacet
+  facet normal 0.989174 0.146746 0
+    outer loop
+      vertex -1.47118 21.4574 0.5
+      vertex -1.49278 21.603 0
+      vertex -1.49278 21.603 0.5
+    endloop
+  endfacet
+  facet normal 0.989174 0.146746 0
+    outer loop
+      vertex -1.49278 21.603 0
+      vertex -1.47118 21.4574 0.5
+      vertex -1.47118 21.4574 0
+    endloop
+  endfacet
+  facet normal 0.336945 0.941524 -0
+    outer loop
+      vertex -0.435427 20.3146 0
+      vertex -0.574024 20.3642 0.5
+      vertex -0.435427 20.3146 0.5
+    endloop
+  endfacet
+  facet normal 0.336945 0.941524 0
+    outer loop
+      vertex -0.574024 20.3642 0.5
+      vertex -0.435427 20.3146 0
+      vertex -0.574024 20.3642 0
+    endloop
+  endfacet
+  facet normal -0.514213 0.857662 0
+    outer loop
+      vertex 0.833355 20.5028 0
+      vertex 0.707094 20.4271 0.5
+      vertex 0.833355 20.5028 0.5
+    endloop
+  endfacet
+  facet normal -0.514213 0.857662 0
+    outer loop
+      vertex 0.707094 20.4271 0.5
+      vertex 0.833355 20.5028 0
+      vertex 0.707094 20.4271 0
+    endloop
+  endfacet
+  facet normal -0.90402 0.427491 0
+    outer loop
+      vertex 1.32288 21.0429 0
+      vertex 1.38582 21.176 0.5
+      vertex 1.38582 21.176 0
+    endloop
+  endfacet
+  facet normal -0.90402 0.427491 0
+    outer loop
+      vertex 1.38582 21.176 0.5
+      vertex 1.32288 21.0429 0
+      vertex 1.32288 21.0429 0.5
+    endloop
+  endfacet
+  facet normal -0.671353 0.741138 0
+    outer loop
+      vertex 1.06066 20.6893 0
+      vertex 0.95159 20.5905 0.5
+      vertex 1.06066 20.6893 0.5
+    endloop
+  endfacet
+  facet normal -0.671353 0.741138 0
+    outer loop
+      vertex 0.95159 20.5905 0.5
+      vertex 1.06066 20.6893 0
+      vertex 0.95159 20.5905 0
+    endloop
+  endfacet
+  facet normal 0.90402 0.427491 0
+    outer loop
+      vertex -1.32288 21.0429 0.5
+      vertex -1.38582 21.176 0
+      vertex -1.38582 21.176 0.5
+    endloop
+  endfacet
+  facet normal 0.90402 0.427491 0
+    outer loop
+      vertex -1.38582 21.176 0
+      vertex -1.32288 21.0429 0.5
+      vertex -1.32288 21.0429 0
+    endloop
+  endfacet
+  facet normal 0.427347 -0.904088 0
+    outer loop
+      vertex -0.707094 23.0729 0
+      vertex -0.574024 23.1358 0.5
+      vertex -0.707094 23.0729 0.5
+    endloop
+  endfacet
+  facet normal 0.427347 -0.904088 0
+    outer loop
+      vertex -0.574024 23.1358 0.5
+      vertex -0.707094 23.0729 0
+      vertex -0.574024 23.1358 0
+    endloop
+  endfacet
+  facet normal 0.146736 0.989176 -0
+    outer loop
+      vertex -0.147025 20.2572 0
+      vertex -0.292635 20.2788 0.5
+      vertex -0.147025 20.2572 0.5
+    endloop
+  endfacet
+  facet normal 0.146736 0.989176 0
+    outer loop
+      vertex -0.292635 20.2788 0.5
+      vertex -0.147025 20.2572 0
+      vertex -0.292635 20.2788 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.4 2.5 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 -2.5 1.5
+      vertex -11.4 2.5 1.5
+      vertex -11.4 -2.5 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.4 25.5 1.5
+      vertex -10.9 20.5 1.5
+      vertex -10.9 25.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -11.4 25.5 1.5
+      vertex -11.4 20.5 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.43541 21.3146 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.47118 21.4574 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.49278 -18.103 1.5
+      vertex 1.5 -18.25 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.38582 21.176 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.43541 21.3146 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.47118 -17.9574 1.5
+      vertex 1.49278 -18.103 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.32288 21.0429 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.38582 21.176 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.43541 -17.8146 1.5
+      vertex 1.47118 -17.9574 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.2472 20.9166 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.32288 21.0429 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.38582 -17.676 1.5
+      vertex 1.43541 -17.8146 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.15952 20.7984 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.2472 20.9166 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.32288 -17.5429 1.5
+      vertex 1.38582 -17.676 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.06066 20.6893 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.15952 20.7984 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.2472 -17.4166 1.5
+      vertex 1.32288 -17.5429 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.95159 20.5905 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.06066 20.6893 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.15952 -17.2984 1.5
+      vertex 1.2472 -17.4166 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.833355 20.5028 1.5
+      vertex 10.9 20.5 1.5
+      vertex 0.95159 20.5905 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.06066 -17.1893 1.5
+      vertex 1.15952 -17.2984 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.707094 20.4271 1.5
+      vertex 10.9 20.5 1.5
+      vertex 0.833355 20.5028 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.95159 -17.0905 1.5
+      vertex 1.06066 -17.1893 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 20.5 1.5
+      vertex 0.707094 20.4271 1.5
+      vertex 10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.833355 -17.0028 1.5
+      vertex 0.95159 -17.0905 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.574024 20.3642 1.5
+      vertex 10.9 2.5 1.5
+      vertex 0.707094 20.4271 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.707094 -16.9271 1.5
+      vertex 0.833355 -17.0028 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.435427 20.3146 1.5
+      vertex 10.9 2.5 1.5
+      vertex 0.574024 20.3642 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 -2.5 1.5
+      vertex 10.9 2.5 1.5
+      vertex -10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.292635 20.2788 1.5
+      vertex 10.9 2.5 1.5
+      vertex 0.435427 20.3146 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.574024 -16.8642 1.5
+      vertex 0.707094 -16.9271 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.147025 20.2572 1.5
+      vertex 10.9 2.5 1.5
+      vertex 0.292635 20.2788 1.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 0.147025 -16.7572 1.5
+      vertex 10.9 2.5 1.5
+      vertex -10.9 -2.5 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 20.25 1.5
+      vertex 10.9 2.5 1.5
+      vertex 0.147025 20.2572 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.435427 -16.8146 1.5
+      vertex 0.574024 -16.8642 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0 20.25 1.5
+      vertex -10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.292635 -16.7788 1.5
+      vertex 0.435427 -16.8146 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 2.5 1.5
+      vertex 0 20.25 1.5
+      vertex -0.147025 20.2572 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 0.147025 -16.7572 1.5
+      vertex 0.292635 -16.7788 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 2.5 1.5
+      vertex -0.147025 20.2572 1.5
+      vertex -0.292635 20.2788 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.147025 -16.7572 1.5
+      vertex -10.9 -2.5 1.5
+      vertex 0 -16.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 2.5 1.5
+      vertex -0.292635 20.2788 1.5
+      vertex -0.435427 20.3146 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -16.75 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.147025 -16.7572 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 2.5 1.5
+      vertex -0.435427 20.3146 1.5
+      vertex -0.574024 20.3642 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.147025 -16.7572 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.292635 -16.7788 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 2.5 1.5
+      vertex -0.574024 20.3642 1.5
+      vertex -0.707094 20.4271 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 -16.7788 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.435427 -16.8146 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -0.707094 20.4271 1.5
+      vertex -0.833355 20.5028 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 -16.8146 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.574024 -16.8642 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -0.833355 20.5028 1.5
+      vertex -0.95159 20.5905 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.574024 -16.8642 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.707094 -16.9271 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -0.95159 20.5905 1.5
+      vertex -1.06066 20.6893 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 -16.9271 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.833355 -17.0028 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.06066 20.6893 1.5
+      vertex -1.15952 20.7984 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.833355 -17.0028 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -0.95159 -17.0905 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.15952 20.7984 1.5
+      vertex -1.2472 20.9166 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.95159 -17.0905 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -1.06066 -17.1893 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.2472 20.9166 1.5
+      vertex -1.32288 21.0429 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 -17.1893 1.5
+      vertex -10.9 -2.5 1.5
+      vertex -1.15952 -17.2984 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.32288 21.0429 1.5
+      vertex -1.38582 21.176 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 -20.5 1.5
+      vertex -1.15952 -17.2984 1.5
+      vertex -10.9 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.38582 21.176 1.5
+      vertex -1.43541 21.3146 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15952 -17.2984 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.2472 -17.4166 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.43541 21.3146 1.5
+      vertex -1.47118 21.4574 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2472 -17.4166 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.32288 -17.5429 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.47118 21.4574 1.5
+      vertex -1.49278 21.603 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.32288 -17.5429 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.38582 -17.676 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.49278 21.603 1.5
+      vertex -1.5 21.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 -17.676 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.43541 -17.8146 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.707094 23.0729 1.5
+      vertex 10.9 25.5 1.5
+      vertex 10.9 34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 1.2472 22.5834 1.5
+      vertex 10.9 25.5 1.5
+      vertex 1.15952 22.7016 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49278 21.603 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.5 21.75 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.47118 21.4574 1.5
+      vertex 10.9 20.5 1.5
+      vertex 1.49278 21.603 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 1.5 -18.25 1.5
+      vertex 10.9 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 20.5 1.5
+      vertex 1.49278 21.897 1.5
+      vertex 1.5 21.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 20.5 1.5
+      vertex 1.47118 22.0426 1.5
+      vertex 1.49278 21.897 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 1.47118 22.0426 1.5
+      vertex 10.9 20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 1.47118 22.0426 1.5
+      vertex 10.9 25.5 1.5
+      vertex 1.43541 22.1854 1.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 1.43541 22.1854 1.5
+      vertex 10.9 25.5 1.5
+      vertex 1.38582 22.324 1.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 1.38582 22.324 1.5
+      vertex 10.9 25.5 1.5
+      vertex 1.32288 22.4571 1.5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 1.32288 22.4571 1.5
+      vertex 10.9 25.5 1.5
+      vertex 1.2472 22.5834 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 1.06066 22.8107 1.5
+      vertex 1.15952 22.7016 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 0.95159 22.9095 1.5
+      vertex 1.06066 22.8107 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 0.833355 22.9972 1.5
+      vertex 0.95159 22.9095 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 0.707094 23.0729 1.5
+      vertex 0.833355 22.9972 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 34.75 1.5
+      vertex 0.574024 23.1358 1.5
+      vertex 0.707094 23.0729 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 34.75 1.5
+      vertex 0.435427 23.1854 1.5
+      vertex 0.574024 23.1358 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 34.75 1.5
+      vertex 0.292635 23.2212 1.5
+      vertex 0.435427 23.1854 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 34.75 1.5
+      vertex 0.147025 23.2428 1.5
+      vertex 0.292635 23.2212 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 34.75 1.5
+      vertex 0 23.25 1.5
+      vertex 0.147025 23.2428 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9 34.75 1.5
+      vertex 0 23.25 1.5
+      vertex 10.9 34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 23.25 1.5
+      vertex -10.9 34.75 1.5
+      vertex -0.147025 23.2428 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.147025 23.2428 1.5
+      vertex -10.9 34.75 1.5
+      vertex -0.292635 23.2212 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 23.2212 1.5
+      vertex -10.9 34.75 1.5
+      vertex -0.435427 23.1854 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 23.1854 1.5
+      vertex -10.9 34.75 1.5
+      vertex -0.574024 23.1358 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.574024 23.1358 1.5
+      vertex -10.9 34.75 1.5
+      vertex -0.707094 23.0729 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9 25.5 1.5
+      vertex -0.707094 23.0729 1.5
+      vertex -10.9 34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 23.0729 1.5
+      vertex -10.9 25.5 1.5
+      vertex -0.833355 22.9972 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 22.0426 1.5
+      vertex -10.9 20.5 1.5
+      vertex -1.49278 21.897 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -1.47118 22.0426 1.5
+      vertex -10.9 25.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 22.1854 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.47118 22.0426 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 22.324 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.43541 22.1854 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.32288 22.4571 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.38582 22.324 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2472 22.5834 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.32288 22.4571 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15952 22.7016 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.2472 22.5834 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 22.8107 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.15952 22.7016 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.95159 22.9095 1.5
+      vertex -10.9 25.5 1.5
+      vertex -1.06066 22.8107 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.833355 22.9972 1.5
+      vertex -10.9 25.5 1.5
+      vertex -0.95159 22.9095 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 11.4 20.5 1.5
+      vertex 11.4 25.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 20.5 1.5
+      vertex 10.9 25.5 1.5
+      vertex 10.9 20.5 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 11.4 -2.5 1.5
+      vertex 11.4 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -2.5 1.5
+      vertex 10.9 2.5 1.5
+      vertex 10.9 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -20.5 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 11.4 -22.75 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 12.5 -34.75 1.5
+      vertex 12.5 -22.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.15952 -19.2016 1.5
+      vertex 11.4 -22.75 1.5
+      vertex 10.9 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9 -2.5 1.5
+      vertex 1.5 -18.25 1.5
+      vertex 10.9 -20.5 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49278 -18.397 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.5 -18.25 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.47118 -18.5426 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.49278 -18.397 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.43541 -18.6854 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.47118 -18.5426 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.38582 -18.824 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.43541 -18.6854 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.32288 -18.9571 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.38582 -18.824 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.2472 -19.0834 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.32288 -18.9571 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.15952 -19.2016 1.5
+      vertex 10.9 -20.5 1.5
+      vertex 1.2472 -19.0834 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 1.15952 -19.2016 1.5
+      vertex 1.06066 -19.3107 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 1.06066 -19.3107 1.5
+      vertex 0.95159 -19.4095 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 0.95159 -19.4095 1.5
+      vertex 0.833355 -19.4972 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 0.833355 -19.4972 1.5
+      vertex 0.707094 -19.5729 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.574024 -19.6358 1.5
+      vertex 11.4 -22.75 1.5
+      vertex 0.707094 -19.5729 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.435427 -19.6854 1.5
+      vertex 11.4 -22.75 1.5
+      vertex 0.574024 -19.6358 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 0.435427 -19.6854 1.5
+      vertex 12.5 -34.75 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.292635 -19.7212 1.5
+      vertex 12.5 -34.75 1.5
+      vertex 0.435427 -19.6854 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.147025 -19.7428 1.5
+      vertex 12.5 -34.75 1.5
+      vertex 0.292635 -19.7212 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -19.75 1.5
+      vertex 12.5 -34.75 1.5
+      vertex 0.147025 -19.7428 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5 -34.75 1.5
+      vertex 0 -19.75 1.5
+      vertex -0.147025 -19.7428 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5 -34.75 1.5
+      vertex -0.147025 -19.7428 1.5
+      vertex -0.292635 -19.7212 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5 -34.75 1.5
+      vertex -0.292635 -19.7212 1.5
+      vertex -0.435427 -19.6854 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -0.435427 -19.6854 1.5
+      vertex -0.574024 -19.6358 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -0.574024 -19.6358 1.5
+      vertex -0.707094 -19.5729 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -0.707094 -19.5729 1.5
+      vertex -0.833355 -19.4972 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -0.833355 -19.4972 1.5
+      vertex -0.95159 -19.4095 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -0.95159 -19.4095 1.5
+      vertex -1.06066 -19.3107 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -1.06066 -19.3107 1.5
+      vertex -1.15952 -19.2016 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 21.897 1.5
+      vertex -10.9 20.5 1.5
+      vertex -1.5 21.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 20.4271 1.5
+      vertex -10.9 20.5 1.5
+      vertex -10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 -17.8146 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.47118 -17.9574 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 -17.9574 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.49278 -18.103 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 -18.103 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.5 -18.25 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.5 -18.25 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.49278 -18.397 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 -18.397 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.47118 -18.5426 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 -18.5426 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.43541 -18.6854 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 -18.6854 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.38582 -18.824 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 -18.824 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -1.32288 -18.9571 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 -20.5 1.5
+      vertex -1.2472 -19.0834 1.5
+      vertex -1.32288 -18.9571 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9 -20.5 1.5
+      vertex -1.15952 -19.2016 1.5
+      vertex -1.2472 -19.0834 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -1.15952 -19.2016 1.5
+      vertex -10.9 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4 -22.75 1.5
+      vertex -10.9 -20.5 1.5
+      vertex -11.4 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 -19.6854 1.5
+      vertex -11.4 -22.75 1.5
+      vertex -12.5 -34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5 -34.75 1.5
+      vertex -11.4 -22.75 1.5
+      vertex -12.5 -22.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -19.75 1.5
+      vertex -12.5 -34.75 1.5
+      vertex 12.5 -34.75 1.5
+    endloop
+  endfacet
+  facet normal 0.595747 0.803172 -0
+    outer loop
+      vertex -0.833355 20.5028 0
+      vertex -0.95159 20.5905 0.5
+      vertex -0.833355 20.5028 0.5
+    endloop
+  endfacet
+  facet normal 0.595747 0.803172 0
+    outer loop
+      vertex -0.95159 20.5905 0.5
+      vertex -0.833355 20.5028 0
+      vertex -0.95159 20.5905 0
+    endloop
+  endfacet
+  facet normal -0.463271 0.419789 -0.780485
+    outer loop
+      vertex 1.15952 20.7984 1.5
+      vertex 1.94454 19.8055 0.5
+      vertex 1.06066 20.6893 1.5
+    endloop
+  endfacet
+  facet normal -0.152029 0.606385 -0.780502
+    outer loop
+      vertex 0.435427 20.3146 1.5
+      vertex 0.536498 19.0528 0.5
+      vertex 0.292635 20.2788 1.5
+    endloop
+  endfacet
+  facet normal -0.624401 -0.0306679 -0.780502
+    outer loop
+      vertex 2.75 21.75 0.5
+      vertex 1.5 21.75 1.5
+      vertex 1.49278 21.897 1.5
+    endloop
+  endfacet
+  facet normal -0.624402 -0.0306756 -0.780501
+    outer loop
+      vertex 2.73676 22.0195 0.5
+      vertex 2.75 21.75 0.5
+      vertex 1.49278 21.897 1.5
+    endloop
+  endfacet
+  facet normal 0.321464 -0.536174 -0.780499
+    outer loop
+      vertex -0.707094 23.0729 1.5
+      vertex -0.833355 22.9972 1.5
+      vertex -1.29634 24.1753 0.5
+    endloop
+  endfacet
+  facet normal -0.267317 0.565118 -0.780502
+    outer loop
+      vertex 1.29634 19.3247 0.5
+      vertex 1.05238 19.2093 0.5
+      vertex 0.707094 20.4271 1.5
+    endloop
+  endfacet
+  facet normal 0.624402 -0.0306756 -0.780501
+    outer loop
+      vertex -2.73676 22.0195 0.5
+      vertex -1.49278 21.897 1.5
+      vertex -2.75 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.5 21.75 0.5
+      vertex 2.75 21.75 0.5
+      vertex 2.73676 22.0195 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.49278 21.897 0.5
+      vertex 2.73676 22.0195 0.5
+      vertex 2.69716 22.2865 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.75 21.75 0.5
+      vertex 1.5 21.75 0.5
+      vertex 2.73676 21.4805 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.47118 22.0426 0.5
+      vertex 2.69716 22.2865 0.5
+      vertex 2.63159 22.5483 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49278 21.603 0.5
+      vertex 2.73676 21.4805 0.5
+      vertex 1.5 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.43541 22.1854 0.5
+      vertex 2.63159 22.5483 0.5
+      vertex 2.54067 22.8024 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.73676 21.4805 0.5
+      vertex 1.49278 21.603 0.5
+      vertex 2.69716 21.2135 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.38582 22.324 0.5
+      vertex 2.54067 22.8024 0.5
+      vertex 2.42528 23.0463 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.47118 21.4574 0.5
+      vertex 2.69716 21.2135 0.5
+      vertex 1.49278 21.603 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.32288 22.4571 0.5
+      vertex 2.42528 23.0463 0.5
+      vertex 2.28654 23.2778 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.69716 21.2135 0.5
+      vertex 1.47118 21.4574 0.5
+      vertex 2.63159 20.9517 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.2472 22.5834 0.5
+      vertex 2.28654 23.2778 0.5
+      vertex 2.12578 23.4946 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.43541 21.3146 0.5
+      vertex 2.63159 20.9517 0.5
+      vertex 1.47118 21.4574 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.15952 22.7016 0.5
+      vertex 2.12578 23.4946 0.5
+      vertex 1.94454 23.6945 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.63159 20.9517 0.5
+      vertex 1.43541 21.3146 0.5
+      vertex 2.54067 20.6976 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.06066 22.8107 0.5
+      vertex 1.94454 23.6945 0.5
+      vertex 1.74458 23.8758 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.38582 21.176 0.5
+      vertex 2.54067 20.6976 0.5
+      vertex 1.43541 21.3146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.95159 22.9095 0.5
+      vertex 1.74458 23.8758 0.5
+      vertex 1.52782 24.0365 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54067 20.6976 0.5
+      vertex 1.38582 21.176 0.5
+      vertex 2.42528 20.4537 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.32288 21.0429 0.5
+      vertex 2.42528 20.4537 0.5
+      vertex 1.38582 21.176 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.73676 22.0195 0.5
+      vertex 1.49278 21.897 0.5
+      vertex 1.5 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.69716 22.2865 0.5
+      vertex 1.47118 22.0426 0.5
+      vertex 1.49278 21.897 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.63159 22.5483 0.5
+      vertex 1.43541 22.1854 0.5
+      vertex 1.47118 22.0426 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54067 22.8024 0.5
+      vertex 1.38582 22.324 0.5
+      vertex 1.43541 22.1854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.42528 23.0463 0.5
+      vertex 1.32288 22.4571 0.5
+      vertex 1.38582 22.324 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.833355 22.9972 0.5
+      vertex 1.52782 24.0365 0.5
+      vertex 1.29634 24.1753 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.28654 23.2778 0.5
+      vertex 1.2472 22.5834 0.5
+      vertex 1.32288 22.4571 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.12578 23.4946 0.5
+      vertex 1.15952 22.7016 0.5
+      vertex 1.2472 22.5834 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.94454 23.6945 0.5
+      vertex 1.06066 22.8107 0.5
+      vertex 1.15952 22.7016 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.707094 23.0729 0.5
+      vertex 1.29634 24.1753 0.5
+      vertex 1.05238 24.2907 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.74458 23.8758 0.5
+      vertex 0.95159 22.9095 0.5
+      vertex 1.06066 22.8107 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.52782 24.0365 0.5
+      vertex 0.833355 22.9972 0.5
+      vertex 0.95159 22.9095 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.574024 23.1358 0.5
+      vertex 1.05238 24.2907 0.5
+      vertex 0.798283 24.3816 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.29634 24.1753 0.5
+      vertex 0.707094 23.0729 0.5
+      vertex 0.833355 22.9972 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.05238 24.2907 0.5
+      vertex 0.574024 23.1358 0.5
+      vertex 0.707094 23.0729 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.435427 23.1854 0.5
+      vertex 0.798283 24.3816 0.5
+      vertex 0.536498 24.4472 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.798283 24.3816 0.5
+      vertex 0.435427 23.1854 0.5
+      vertex 0.574024 23.1358 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.536498 24.4472 0.5
+      vertex 0.292635 23.2212 0.5
+      vertex 0.435427 23.1854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.269547 24.4868 0.5
+      vertex 0.292635 23.2212 0.5
+      vertex 0.536498 24.4472 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.269547 24.4868 0.5
+      vertex 0.147025 23.2428 0.5
+      vertex 0.292635 23.2212 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 24.5 0.5
+      vertex 0.147025 23.2428 0.5
+      vertex 0.269547 24.4868 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 24.5 0.5
+      vertex 0 23.25 0.5
+      vertex 0.147025 23.2428 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 24.5 0.5
+      vertex -0.147025 23.2428 0.5
+      vertex 0 23.25 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.269547 24.4868 0.5
+      vertex -0.147025 23.2428 0.5
+      vertex 0 24.5 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.269547 24.4868 0.5
+      vertex -0.292635 23.2212 0.5
+      vertex -0.147025 23.2428 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.536498 24.4472 0.5
+      vertex -0.292635 23.2212 0.5
+      vertex -0.269547 24.4868 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 23.2212 0.5
+      vertex -0.536498 24.4472 0.5
+      vertex -0.435427 23.1854 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.798283 24.3816 0.5
+      vertex -0.435427 23.1854 0.5
+      vertex -0.536498 24.4472 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 23.1854 0.5
+      vertex -0.798283 24.3816 0.5
+      vertex -0.574024 23.1358 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.05238 24.2907 0.5
+      vertex -0.574024 23.1358 0.5
+      vertex -0.798283 24.3816 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.574024 23.1358 0.5
+      vertex -1.05238 24.2907 0.5
+      vertex -0.707094 23.0729 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.29634 24.1753 0.5
+      vertex -0.707094 23.0729 0.5
+      vertex -1.05238 24.2907 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 23.0729 0.5
+      vertex -1.29634 24.1753 0.5
+      vertex -0.833355 22.9972 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.52782 24.0365 0.5
+      vertex -0.833355 22.9972 0.5
+      vertex -1.29634 24.1753 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.833355 22.9972 0.5
+      vertex -1.52782 24.0365 0.5
+      vertex -0.95159 22.9095 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.74458 23.8758 0.5
+      vertex -0.95159 22.9095 0.5
+      vertex -1.52782 24.0365 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.95159 22.9095 0.5
+      vertex -1.74458 23.8758 0.5
+      vertex -1.06066 22.8107 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.94454 23.6945 0.5
+      vertex -1.06066 22.8107 0.5
+      vertex -1.74458 23.8758 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 22.8107 0.5
+      vertex -1.94454 23.6945 0.5
+      vertex -1.15952 22.7016 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.12578 23.4946 0.5
+      vertex -1.15952 22.7016 0.5
+      vertex -1.94454 23.6945 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15952 22.7016 0.5
+      vertex -2.12578 23.4946 0.5
+      vertex -1.2472 22.5834 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.28654 23.2778 0.5
+      vertex -1.2472 22.5834 0.5
+      vertex -2.12578 23.4946 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.42528 23.0463 0.5
+      vertex -1.32288 22.4571 0.5
+      vertex -2.28654 23.2778 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2472 22.5834 0.5
+      vertex -2.28654 23.2778 0.5
+      vertex -1.32288 22.4571 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.42528 20.4537 0.5
+      vertex 1.32288 21.0429 0.5
+      vertex 2.28654 20.2222 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.2472 20.9166 0.5
+      vertex 2.28654 20.2222 0.5
+      vertex 1.32288 21.0429 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.28654 20.2222 0.5
+      vertex 1.2472 20.9166 0.5
+      vertex 2.12578 20.0054 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.15952 20.7984 0.5
+      vertex 2.12578 20.0054 0.5
+      vertex 1.2472 20.9166 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.12578 20.0054 0.5
+      vertex 1.15952 20.7984 0.5
+      vertex 1.94454 19.8055 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.06066 20.6893 0.5
+      vertex 1.94454 19.8055 0.5
+      vertex 1.15952 20.7984 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.94454 19.8055 0.5
+      vertex 1.06066 20.6893 0.5
+      vertex 1.74458 19.6242 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.95159 20.5905 0.5
+      vertex 1.74458 19.6242 0.5
+      vertex 1.06066 20.6893 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.74458 19.6242 0.5
+      vertex 0.95159 20.5905 0.5
+      vertex 1.52782 19.4635 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.833355 20.5028 0.5
+      vertex 1.52782 19.4635 0.5
+      vertex 0.95159 20.5905 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.52782 19.4635 0.5
+      vertex 0.833355 20.5028 0.5
+      vertex 1.29634 19.3247 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.707094 20.4271 0.5
+      vertex 1.29634 19.3247 0.5
+      vertex 0.833355 20.5028 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.29634 19.3247 0.5
+      vertex 0.707094 20.4271 0.5
+      vertex 1.05238 19.2093 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.574024 20.3642 0.5
+      vertex 1.05238 19.2093 0.5
+      vertex 0.707094 20.4271 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.05238 19.2093 0.5
+      vertex 0.574024 20.3642 0.5
+      vertex 0.798283 19.1184 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.435427 20.3146 0.5
+      vertex 0.798283 19.1184 0.5
+      vertex 0.574024 20.3642 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.798283 19.1184 0.5
+      vertex 0.435427 20.3146 0.5
+      vertex 0.536498 19.0528 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.292635 20.2788 0.5
+      vertex 0.536498 19.0528 0.5
+      vertex 0.435427 20.3146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.292635 20.2788 0.5
+      vertex 0.269547 19.0132 0.5
+      vertex 0.536498 19.0528 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.147025 20.2572 0.5
+      vertex 0.269547 19.0132 0.5
+      vertex 0.292635 20.2788 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 20.25 0.5
+      vertex 0.269547 19.0132 0.5
+      vertex 0.147025 20.2572 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20.25 0.5
+      vertex 0 19 0.5
+      vertex 0.269547 19.0132 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.147025 20.2572 0.5
+      vertex 0 19 0.5
+      vertex 0 20.25 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.147025 20.2572 0.5
+      vertex -0.269547 19.0132 0.5
+      vertex 0 19 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 20.2788 0.5
+      vertex -0.269547 19.0132 0.5
+      vertex -0.147025 20.2572 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.536498 19.0528 0.5
+      vertex -0.292635 20.2788 0.5
+      vertex -0.435427 20.3146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 20.2788 0.5
+      vertex -0.536498 19.0528 0.5
+      vertex -0.269547 19.0132 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.798283 19.1184 0.5
+      vertex -0.435427 20.3146 0.5
+      vertex -0.574024 20.3642 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.05238 19.2093 0.5
+      vertex -0.574024 20.3642 0.5
+      vertex -0.707094 20.4271 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 20.3146 0.5
+      vertex -0.798283 19.1184 0.5
+      vertex -0.536498 19.0528 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.29634 19.3247 0.5
+      vertex -0.707094 20.4271 0.5
+      vertex -0.833355 20.5028 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.52782 19.4635 0.5
+      vertex -0.833355 20.5028 0.5
+      vertex -0.95159 20.5905 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.574024 20.3642 0.5
+      vertex -1.05238 19.2093 0.5
+      vertex -0.798283 19.1184 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.74458 19.6242 0.5
+      vertex -0.95159 20.5905 0.5
+      vertex -1.06066 20.6893 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.94454 19.8055 0.5
+      vertex -1.06066 20.6893 0.5
+      vertex -1.15952 20.7984 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.12578 20.0054 0.5
+      vertex -1.15952 20.7984 0.5
+      vertex -1.2472 20.9166 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 20.4271 0.5
+      vertex -1.29634 19.3247 0.5
+      vertex -1.05238 19.2093 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.28654 20.2222 0.5
+      vertex -1.2472 20.9166 0.5
+      vertex -1.32288 21.0429 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.42528 20.4537 0.5
+      vertex -1.32288 21.0429 0.5
+      vertex -1.38582 21.176 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.54067 20.6976 0.5
+      vertex -1.38582 21.176 0.5
+      vertex -1.43541 21.3146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.63159 20.9517 0.5
+      vertex -1.43541 21.3146 0.5
+      vertex -1.47118 21.4574 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.69716 21.2135 0.5
+      vertex -1.47118 21.4574 0.5
+      vertex -1.49278 21.603 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.833355 20.5028 0.5
+      vertex -1.52782 19.4635 0.5
+      vertex -1.29634 19.3247 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.73676 21.4805 0.5
+      vertex -1.49278 21.603 0.5
+      vertex -1.5 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.32288 22.4571 0.5
+      vertex -2.42528 23.0463 0.5
+      vertex -1.38582 22.324 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.54067 22.8024 0.5
+      vertex -1.38582 22.324 0.5
+      vertex -2.42528 23.0463 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.95159 20.5905 0.5
+      vertex -1.74458 19.6242 0.5
+      vertex -1.52782 19.4635 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 22.324 0.5
+      vertex -2.54067 22.8024 0.5
+      vertex -1.43541 22.1854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 20.6893 0.5
+      vertex -1.94454 19.8055 0.5
+      vertex -1.74458 19.6242 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.63159 22.5483 0.5
+      vertex -1.43541 22.1854 0.5
+      vertex -2.54067 22.8024 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15952 20.7984 0.5
+      vertex -2.12578 20.0054 0.5
+      vertex -1.94454 19.8055 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 22.1854 0.5
+      vertex -2.63159 22.5483 0.5
+      vertex -1.47118 22.0426 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2472 20.9166 0.5
+      vertex -2.28654 20.2222 0.5
+      vertex -2.12578 20.0054 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.69716 22.2865 0.5
+      vertex -1.47118 22.0426 0.5
+      vertex -2.63159 22.5483 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.32288 21.0429 0.5
+      vertex -2.42528 20.4537 0.5
+      vertex -2.28654 20.2222 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 22.0426 0.5
+      vertex -2.69716 22.2865 0.5
+      vertex -1.49278 21.897 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 21.176 0.5
+      vertex -2.54067 20.6976 0.5
+      vertex -2.42528 20.4537 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.73676 22.0195 0.5
+      vertex -1.49278 21.897 0.5
+      vertex -2.69716 22.2865 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 21.3146 0.5
+      vertex -2.63159 20.9517 0.5
+      vertex -2.54067 20.6976 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 21.897 0.5
+      vertex -2.73676 22.0195 0.5
+      vertex -1.5 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 21.4574 0.5
+      vertex -2.69716 21.2135 0.5
+      vertex -2.63159 20.9517 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.75 21.75 0.5
+      vertex -1.5 21.75 0.5
+      vertex -2.73676 22.0195 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 21.603 0.5
+      vertex -2.73676 21.4805 0.5
+      vertex -2.69716 21.2135 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.5 21.75 0.5
+      vertex -2.75 21.75 0.5
+      vertex -2.73676 21.4805 0.5
+    endloop
+  endfacet
+  facet normal 0.267317 0.565118 -0.780502
+    outer loop
+      vertex -0.707094 20.4271 1.5
+      vertex -1.05238 19.2093 0.5
+      vertex -1.29634 19.3247 0.5
+    endloop
+  endfacet
+  facet normal 0.26715 -0.565177 -0.780516
+    outer loop
+      vertex -0.574024 23.1358 1.5
+      vertex -0.707094 23.0729 1.5
+      vertex -1.05238 24.2907 0.5
+    endloop
+  endfacet
+  facet normal -0.0305777 0.624403 -0.780504
+    outer loop
+      vertex 0.147025 20.2572 1.5
+      vertex 0.269547 19.0132 0.5
+      vertex 0 19 0.5
+    endloop
+  endfacet
+  facet normal -0.21057 -0.588615 -0.780508
+    outer loop
+      vertex 0.798283 24.3816 0.5
+      vertex 1.05238 24.2907 0.5
+      vertex 0.435427 23.1854 1.5
+    endloop
+  endfacet
+  facet normal -0.588604 -0.210609 -0.780506
+    outer loop
+      vertex 2.54067 22.8024 0.5
+      vertex 2.63159 22.5483 0.5
+      vertex 1.43541 22.1854 1.5
+    endloop
+  endfacet
+  facet normal 0.151955 -0.606396 -0.780509
+    outer loop
+      vertex -0.536498 24.4472 0.5
+      vertex -0.435427 23.1854 1.5
+      vertex -0.798283 24.3816 0.5
+    endloop
+  endfacet
+  facet normal 0.565106 -0.267354 -0.780498
+    outer loop
+      vertex -2.42528 23.0463 0.5
+      vertex -1.32288 22.4571 1.5
+      vertex -2.54067 22.8024 0.5
+    endloop
+  endfacet
+  facet normal 0.502162 0.37236 -0.780501
+    outer loop
+      vertex -1.15952 20.7984 1.5
+      vertex -2.12578 20.0054 0.5
+      vertex -2.28654 20.2222 0.5
+    endloop
+  endfacet
+  facet normal 0.502162 -0.37236 -0.780501
+    outer loop
+      vertex -2.12578 23.4946 0.5
+      vertex -1.15952 22.7016 1.5
+      vertex -2.28654 23.2778 0.5
+    endloop
+  endfacet
+  facet normal -0.46314 -0.419907 -0.7805
+    outer loop
+      vertex 1.94454 23.6945 0.5
+      vertex 2.12578 23.4946 0.5
+      vertex 1.15952 22.7016 1.5
+    endloop
+  endfacet
+  facet normal 0.606419 0.151883 -0.780505
+    outer loop
+      vertex -1.43541 21.3146 1.5
+      vertex -2.63159 20.9517 0.5
+      vertex -2.69716 21.2135 0.5
+    endloop
+  endfacet
+  facet normal -0.618385 -0.0917384 -0.780503
+    outer loop
+      vertex 2.69716 22.2865 0.5
+      vertex 1.49278 21.897 1.5
+      vertex 1.47118 22.0426 1.5
+    endloop
+  endfacet
+  facet normal -0.618391 0.0917163 -0.780501
+    outer loop
+      vertex 2.73676 21.4805 0.5
+      vertex 2.69716 21.2135 0.5
+      vertex 1.49278 21.603 1.5
+    endloop
+  endfacet
+  facet normal -0.536257 -0.32133 -0.780497
+    outer loop
+      vertex 2.42528 23.0463 0.5
+      vertex 1.32288 22.4571 1.5
+      vertex 1.2472 22.5834 1.5
+    endloop
+  endfacet
+  facet normal 0.618391 0.0917163 -0.780501
+    outer loop
+      vertex -1.49278 21.603 1.5
+      vertex -2.69716 21.2135 0.5
+      vertex -2.73676 21.4805 0.5
+    endloop
+  endfacet
+  facet normal -0.463271 -0.419789 -0.780485
+    outer loop
+      vertex 1.94454 23.6945 0.5
+      vertex 1.15952 22.7016 1.5
+      vertex 1.06066 22.8107 1.5
+    endloop
+  endfacet
+  facet normal -0.565145 -0.267244 -0.780507
+    outer loop
+      vertex 2.54067 22.8024 0.5
+      vertex 1.38582 22.324 1.5
+      vertex 1.32288 22.4571 1.5
+    endloop
+  endfacet
+  facet normal -0.210637 0.588583 -0.780514
+    outer loop
+      vertex 0.574024 20.3642 1.5
+      vertex 1.05238 19.2093 0.5
+      vertex 0.435427 20.3146 1.5
+    endloop
+  endfacet
+  facet normal -0.210637 -0.588583 -0.780514
+    outer loop
+      vertex 1.05238 24.2907 0.5
+      vertex 0.574024 23.1358 1.5
+      vertex 0.435427 23.1854 1.5
+    endloop
+  endfacet
+  facet normal 0.624402 0.0306756 -0.780501
+    outer loop
+      vertex -1.49278 21.603 1.5
+      vertex -2.73676 21.4805 0.5
+      vertex -2.75 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0.321464 0.536174 -0.780499
+    outer loop
+      vertex -0.833355 20.5028 1.5
+      vertex -0.707094 20.4271 1.5
+      vertex -1.29634 19.3247 0.5
+    endloop
+  endfacet
+  facet normal 0.0305778 -0.624403 -0.780504
+    outer loop
+      vertex 0 24.5 0.5
+      vertex 0 23.25 1.5
+      vertex -0.147025 23.2428 1.5
+    endloop
+  endfacet
+  facet normal 0.419716 0.463344 -0.780481
+    outer loop
+      vertex -1.06066 20.6893 1.5
+      vertex -0.95159 20.5905 1.5
+      vertex -1.94454 19.8055 0.5
+    endloop
+  endfacet
+  facet normal 0.321492 -0.53616 -0.780497
+    outer loop
+      vertex -1.29634 24.1753 0.5
+      vertex -0.833355 22.9972 1.5
+      vertex -1.52782 24.0365 0.5
+    endloop
+  endfacet
+  facet normal -0.536237 0.321372 -0.780493
+    outer loop
+      vertex 2.42528 20.4537 0.5
+      vertex 2.28654 20.2222 0.5
+      vertex 1.2472 20.9166 1.5
+    endloop
+  endfacet
+  facet normal -0.26715 0.565177 -0.780516
+    outer loop
+      vertex 0.707094 20.4271 1.5
+      vertex 1.05238 19.2093 0.5
+      vertex 0.574024 20.3642 1.5
+    endloop
+  endfacet
+  facet normal 0.606419 -0.151883 -0.780505
+    outer loop
+      vertex -2.63159 22.5483 0.5
+      vertex -1.43541 22.1854 1.5
+      vertex -2.69716 22.2865 0.5
+    endloop
+  endfacet
+  facet normal -0.0917319 0.618382 -0.780506
+    outer loop
+      vertex 0.536498 19.0528 0.5
+      vertex 0.269547 19.0132 0.5
+      vertex 0.147025 20.2572 1.5
+    endloop
+  endfacet
+  facet normal -0.0917316 0.618382 -0.780506
+    outer loop
+      vertex 0.292635 20.2788 1.5
+      vertex 0.536498 19.0528 0.5
+      vertex 0.147025 20.2572 1.5
+    endloop
+  endfacet
+  facet normal 0.618385 -0.0917384 -0.780503
+    outer loop
+      vertex -1.47118 22.0426 1.5
+      vertex -1.49278 21.897 1.5
+      vertex -2.69716 22.2865 0.5
+    endloop
+  endfacet
+  facet normal -0.606419 -0.151883 -0.780505
+    outer loop
+      vertex 2.63159 22.5483 0.5
+      vertex 2.69716 22.2865 0.5
+      vertex 1.43541 22.1854 1.5
+    endloop
+  endfacet
+  facet normal 0.606416 0.151901 -0.780503
+    outer loop
+      vertex -1.47118 21.4574 1.5
+      vertex -1.43541 21.3146 1.5
+      vertex -2.69716 21.2135 0.5
+    endloop
+  endfacet
+  facet normal 0.588604 0.210609 -0.780506
+    outer loop
+      vertex -1.43541 21.3146 1.5
+      vertex -2.54067 20.6976 0.5
+      vertex -2.63159 20.9517 0.5
+    endloop
+  endfacet
+  facet normal 0.565145 0.267244 -0.780507
+    outer loop
+      vertex -1.38582 21.176 1.5
+      vertex -1.32288 21.0429 1.5
+      vertex -2.54067 20.6976 0.5
+    endloop
+  endfacet
+  facet normal -0.606416 0.151901 -0.780503
+    outer loop
+      vertex 1.47118 21.4574 1.5
+      vertex 2.69716 21.2135 0.5
+      vertex 1.43541 21.3146 1.5
+    endloop
+  endfacet
+  facet normal -0.606416 -0.151901 -0.780503
+    outer loop
+      vertex 2.69716 22.2865 0.5
+      vertex 1.47118 22.0426 1.5
+      vertex 1.43541 22.1854 1.5
+    endloop
+  endfacet
+  facet normal -0.41991 -0.463128 -0.780505
+    outer loop
+      vertex 1.74458 23.8758 0.5
+      vertex 1.94454 23.6945 0.5
+      vertex 0.95159 22.9095 1.5
+    endloop
+  endfacet
+  facet normal -0.618391 -0.0917163 -0.780501
+    outer loop
+      vertex 2.69716 22.2865 0.5
+      vertex 2.73676 22.0195 0.5
+      vertex 1.49278 21.897 1.5
+    endloop
+  endfacet
+  facet normal -0.321464 -0.536174 -0.780499
+    outer loop
+      vertex 1.29634 24.1753 0.5
+      vertex 0.833355 22.9972 1.5
+      vertex 0.707094 23.0729 1.5
+    endloop
+  endfacet
+  facet normal 0.536257 -0.32133 -0.780497
+    outer loop
+      vertex -1.2472 22.5834 1.5
+      vertex -1.32288 22.4571 1.5
+      vertex -2.42528 23.0463 0.5
+    endloop
+  endfacet
+  facet normal 0.624401 0.0306679 -0.780502
+    outer loop
+      vertex -1.5 21.75 1.5
+      vertex -1.49278 21.603 1.5
+      vertex -2.75 21.75 0.5
+    endloop
+  endfacet
+  facet normal 0.210637 -0.588583 -0.780514
+    outer loop
+      vertex -0.435427 23.1854 1.5
+      vertex -0.574024 23.1358 1.5
+      vertex -1.05238 24.2907 0.5
+    endloop
+  endfacet
+  facet normal 0.565106 0.267354 -0.780498
+    outer loop
+      vertex -1.32288 21.0429 1.5
+      vertex -2.42528 20.4537 0.5
+      vertex -2.54067 20.6976 0.5
+    endloop
+  endfacet
+  facet normal -0.536257 0.32133 -0.780497
+    outer loop
+      vertex 1.32288 21.0429 1.5
+      vertex 2.42528 20.4537 0.5
+      vertex 1.2472 20.9166 1.5
+    endloop
+  endfacet
+  facet normal -0.321492 0.53616 -0.780497
+    outer loop
+      vertex 1.52782 19.4635 0.5
+      vertex 1.29634 19.3247 0.5
+      vertex 0.833355 20.5028 1.5
+    endloop
+  endfacet
+  facet normal -0.606419 0.151883 -0.780505
+    outer loop
+      vertex 2.69716 21.2135 0.5
+      vertex 2.63159 20.9517 0.5
+      vertex 1.43541 21.3146 1.5
+    endloop
+  endfacet
+  facet normal 0.588604 -0.210609 -0.780506
+    outer loop
+      vertex -2.54067 22.8024 0.5
+      vertex -1.43541 22.1854 1.5
+      vertex -2.63159 22.5483 0.5
+    endloop
+  endfacet
+  facet normal -0.565106 0.267354 -0.780498
+    outer loop
+      vertex 2.54067 20.6976 0.5
+      vertex 2.42528 20.4537 0.5
+      vertex 1.32288 21.0429 1.5
+    endloop
+  endfacet
+  facet normal 0.0305777 0.624403 -0.780504
+    outer loop
+      vertex -0.147025 20.2572 1.5
+      vertex 0 19 0.5
+      vertex -0.269547 19.0132 0.5
+    endloop
+  endfacet
+  facet normal 0.606416 -0.151901 -0.780503
+    outer loop
+      vertex -1.43541 22.1854 1.5
+      vertex -1.47118 22.0426 1.5
+      vertex -2.69716 22.2865 0.5
+    endloop
+  endfacet
+  facet normal 0.26715 0.565177 -0.780516
+    outer loop
+      vertex -0.707094 20.4271 1.5
+      vertex -0.574024 20.3642 1.5
+      vertex -1.05238 19.2093 0.5
+    endloop
+  endfacet
+  facet normal -0.152029 -0.606385 -0.780502
+    outer loop
+      vertex 0.536498 24.4472 0.5
+      vertex 0.435427 23.1854 1.5
+      vertex 0.292635 23.2212 1.5
+    endloop
+  endfacet
+  facet normal -0.372311 -0.502191 -0.780506
+    outer loop
+      vertex 1.52782 24.0365 0.5
+      vertex 1.74458 23.8758 0.5
+      vertex 0.95159 22.9095 1.5
+    endloop
+  endfacet
+  facet normal 0.536257 0.32133 -0.780497
+    outer loop
+      vertex -1.32288 21.0429 1.5
+      vertex -1.2472 20.9166 1.5
+      vertex -2.42528 20.4537 0.5
+    endloop
+  endfacet
+  facet normal -0.21057 0.588615 -0.780508
+    outer loop
+      vertex 1.05238 19.2093 0.5
+      vertex 0.798283 19.1184 0.5
+      vertex 0.435427 20.3146 1.5
+    endloop
+  endfacet
+  facet normal 0.37244 -0.502114 -0.780494
+    outer loop
+      vertex -0.833355 22.9972 1.5
+      vertex -0.95159 22.9095 1.5
+      vertex -1.52782 24.0365 0.5
+    endloop
+  endfacet
+  facet normal -0.26715 -0.565177 -0.780516
+    outer loop
+      vertex 1.05238 24.2907 0.5
+      vertex 0.707094 23.0729 1.5
+      vertex 0.574024 23.1358 1.5
+    endloop
+  endfacet
+  facet normal 0.0917319 -0.618382 -0.780506
+    outer loop
+      vertex -0.269547 24.4868 0.5
+      vertex -0.147025 23.2428 1.5
+      vertex -0.536498 24.4472 0.5
+    endloop
+  endfacet
+  facet normal -0.502162 -0.37236 -0.780501
+    outer loop
+      vertex 2.12578 23.4946 0.5
+      vertex 2.28654 23.2778 0.5
+      vertex 1.15952 22.7016 1.5
+    endloop
+  endfacet
+  facet normal -0.419716 -0.463344 -0.780481
+    outer loop
+      vertex 1.94454 23.6945 0.5
+      vertex 1.06066 22.8107 1.5
+      vertex 0.95159 22.9095 1.5
+    endloop
+  endfacet
+  facet normal -0.267317 -0.565118 -0.780502
+    outer loop
+      vertex 1.05238 24.2907 0.5
+      vertex 1.29634 24.1753 0.5
+      vertex 0.707094 23.0729 1.5
+    endloop
+  endfacet
+  facet normal -0.565106 -0.267354 -0.780498
+    outer loop
+      vertex 2.42528 23.0463 0.5
+      vertex 2.54067 22.8024 0.5
+      vertex 1.32288 22.4571 1.5
+    endloop
+  endfacet
+  facet normal -0.151955 0.606396 -0.780509
+    outer loop
+      vertex 0.798283 19.1184 0.5
+      vertex 0.536498 19.0528 0.5
+      vertex 0.435427 20.3146 1.5
+    endloop
+  endfacet
+  facet normal -0.41991 0.463128 -0.780505
+    outer loop
+      vertex 1.94454 19.8055 0.5
+      vertex 1.74458 19.6242 0.5
+      vertex 0.95159 20.5905 1.5
+    endloop
+  endfacet
+  facet normal 0.37244 0.502114 -0.780494
+    outer loop
+      vertex -0.95159 20.5905 1.5
+      vertex -0.833355 20.5028 1.5
+      vertex -1.52782 19.4635 0.5
+    endloop
+  endfacet
+  facet normal -0.624402 0.0306756 -0.780501
+    outer loop
+      vertex 2.75 21.75 0.5
+      vertex 2.73676 21.4805 0.5
+      vertex 1.49278 21.603 1.5
+    endloop
+  endfacet
+  facet normal -0.624401 0.0306679 -0.780502
+    outer loop
+      vertex 1.5 21.75 1.5
+      vertex 2.75 21.75 0.5
+      vertex 1.49278 21.603 1.5
+    endloop
+  endfacet
+  facet normal -0.502104 0.372458 -0.780491
+    outer loop
+      vertex 1.2472 20.9166 1.5
+      vertex 2.28654 20.2222 0.5
+      vertex 1.15952 20.7984 1.5
+    endloop
+  endfacet
+  facet normal -0.0305778 -0.624403 -0.780504
+    outer loop
+      vertex 0 24.5 0.5
+      vertex 0.147025 23.2428 1.5
+      vertex 0 23.25 1.5
+    endloop
+  endfacet
+  facet normal 0.372311 0.502191 -0.780506
+    outer loop
+      vertex -0.95159 20.5905 1.5
+      vertex -1.52782 19.4635 0.5
+      vertex -1.74458 19.6242 0.5
+    endloop
+  endfacet
+  facet normal 0.41991 0.463128 -0.780505
+    outer loop
+      vertex -0.95159 20.5905 1.5
+      vertex -1.74458 19.6242 0.5
+      vertex -1.94454 19.8055 0.5
+    endloop
+  endfacet
+  facet normal 0.210637 0.588583 -0.780514
+    outer loop
+      vertex -0.574024 20.3642 1.5
+      vertex -0.435427 20.3146 1.5
+      vertex -1.05238 19.2093 0.5
+    endloop
+  endfacet
+  facet normal -0.372311 0.502191 -0.780506
+    outer loop
+      vertex 1.74458 19.6242 0.5
+      vertex 1.52782 19.4635 0.5
+      vertex 0.95159 20.5905 1.5
+    endloop
+  endfacet
+  facet normal -0.419716 0.463344 -0.780481
+    outer loop
+      vertex 1.06066 20.6893 1.5
+      vertex 1.94454 19.8055 0.5
+      vertex 0.95159 20.5905 1.5
+    endloop
+  endfacet
+  facet normal -0.502162 0.37236 -0.780501
+    outer loop
+      vertex 2.28654 20.2222 0.5
+      vertex 2.12578 20.0054 0.5
+      vertex 1.15952 20.7984 1.5
+    endloop
+  endfacet
+  facet normal -0.46314 0.419907 -0.7805
+    outer loop
+      vertex 2.12578 20.0054 0.5
+      vertex 1.94454 19.8055 0.5
+      vertex 1.15952 20.7984 1.5
+    endloop
+  endfacet
+  facet normal 0.536237 -0.321372 -0.780493
+    outer loop
+      vertex -2.28654 23.2778 0.5
+      vertex -1.2472 22.5834 1.5
+      vertex -2.42528 23.0463 0.5
+    endloop
+  endfacet
+  facet normal -0.151955 -0.606396 -0.780509
+    outer loop
+      vertex 0.536498 24.4472 0.5
+      vertex 0.798283 24.3816 0.5
+      vertex 0.435427 23.1854 1.5
+    endloop
+  endfacet
+  facet normal 0.588608 0.210599 -0.780505
+    outer loop
+      vertex -1.43541 21.3146 1.5
+      vertex -1.38582 21.176 1.5
+      vertex -2.54067 20.6976 0.5
+    endloop
+  endfacet
+  facet normal -0.37244 -0.502114 -0.780494
+    outer loop
+      vertex 1.52782 24.0365 0.5
+      vertex 0.95159 22.9095 1.5
+      vertex 0.833355 22.9972 1.5
+    endloop
+  endfacet
+  facet normal 0.624401 -0.0306679 -0.780502
+    outer loop
+      vertex -1.49278 21.897 1.5
+      vertex -1.5 21.75 1.5
+      vertex -2.75 21.75 0.5
+    endloop
+  endfacet
+  facet normal -0.565145 0.267244 -0.780507
+    outer loop
+      vertex 1.38582 21.176 1.5
+      vertex 2.54067 20.6976 0.5
+      vertex 1.32288 21.0429 1.5
+    endloop
+  endfacet
+  facet normal -0.502104 -0.372458 -0.780491
+    outer loop
+      vertex 2.28654 23.2778 0.5
+      vertex 1.2472 22.5834 1.5
+      vertex 1.15952 22.7016 1.5
+    endloop
+  endfacet
+  facet normal 0.502104 -0.372458 -0.780491
+    outer loop
+      vertex -1.15952 22.7016 1.5
+      vertex -1.2472 22.5834 1.5
+      vertex -2.28654 23.2778 0.5
+    endloop
+  endfacet
+  facet normal 0.463271 -0.419789 -0.780485
+    outer loop
+      vertex -1.06066 22.8107 1.5
+      vertex -1.15952 22.7016 1.5
+      vertex -1.94454 23.6945 0.5
+    endloop
+  endfacet
+  facet normal -0.0305778 0.624403 -0.780504
+    outer loop
+      vertex 0 20.25 1.5
+      vertex 0.147025 20.2572 1.5
+      vertex 0 19 0.5
+    endloop
+  endfacet
+  facet normal -0.588608 0.210599 -0.780505
+    outer loop
+      vertex 1.43541 21.3146 1.5
+      vertex 2.54067 20.6976 0.5
+      vertex 1.38582 21.176 1.5
+    endloop
+  endfacet
+  facet normal -0.588604 0.210609 -0.780506
+    outer loop
+      vertex 2.63159 20.9517 0.5
+      vertex 2.54067 20.6976 0.5
+      vertex 1.43541 21.3146 1.5
+    endloop
+  endfacet
+  facet normal 0.41991 -0.463128 -0.780505
+    outer loop
+      vertex -1.74458 23.8758 0.5
+      vertex -0.95159 22.9095 1.5
+      vertex -1.94454 23.6945 0.5
+    endloop
+  endfacet
+  facet normal 0.46314 -0.419907 -0.7805
+    outer loop
+      vertex -1.94454 23.6945 0.5
+      vertex -1.15952 22.7016 1.5
+      vertex -2.12578 23.4946 0.5
+    endloop
+  endfacet
+  facet normal 0.588608 -0.210599 -0.780505
+    outer loop
+      vertex -1.38582 22.324 1.5
+      vertex -1.43541 22.1854 1.5
+      vertex -2.54067 22.8024 0.5
+    endloop
+  endfacet
+  facet normal 0.21057 -0.588615 -0.780508
+    outer loop
+      vertex -0.798283 24.3816 0.5
+      vertex -0.435427 23.1854 1.5
+      vertex -1.05238 24.2907 0.5
+    endloop
+  endfacet
+  facet normal -0.321492 -0.53616 -0.780497
+    outer loop
+      vertex 1.29634 24.1753 0.5
+      vertex 1.52782 24.0365 0.5
+      vertex 0.833355 22.9972 1.5
+    endloop
+  endfacet
+  facet normal -0.588608 -0.210599 -0.780505
+    outer loop
+      vertex 2.54067 22.8024 0.5
+      vertex 1.43541 22.1854 1.5
+      vertex 1.38582 22.324 1.5
+    endloop
+  endfacet
+  facet normal 0.267317 -0.565118 -0.780502
+    outer loop
+      vertex -1.05238 24.2907 0.5
+      vertex -0.707094 23.0729 1.5
+      vertex -1.29634 24.1753 0.5
+    endloop
+  endfacet
+  facet normal 0.419716 -0.463344 -0.780481
+    outer loop
+      vertex -0.95159 22.9095 1.5
+      vertex -1.06066 22.8107 1.5
+      vertex -1.94454 23.6945 0.5
+    endloop
+  endfacet
+  facet normal -0.536237 -0.321372 -0.780493
+    outer loop
+      vertex 2.28654 23.2778 0.5
+      vertex 2.42528 23.0463 0.5
+      vertex 1.2472 22.5834 1.5
+    endloop
+  endfacet
+  facet normal 0.536237 0.321372 -0.780493
+    outer loop
+      vertex -1.2472 20.9166 1.5
+      vertex -2.28654 20.2222 0.5
+      vertex -2.42528 20.4537 0.5
+    endloop
+  endfacet
+  facet normal -0.0305777 -0.624403 -0.780504
+    outer loop
+      vertex 0.269547 24.4868 0.5
+      vertex 0.147025 23.2428 1.5
+      vertex 0 24.5 0.5
+    endloop
+  endfacet
+  facet normal 0.618385 0.0917384 -0.780503
+    outer loop
+      vertex -1.49278 21.603 1.5
+      vertex -1.47118 21.4574 1.5
+      vertex -2.69716 21.2135 0.5
+    endloop
+  endfacet
+  facet normal 0.46314 0.419907 -0.7805
+    outer loop
+      vertex -1.15952 20.7984 1.5
+      vertex -1.94454 19.8055 0.5
+      vertex -2.12578 20.0054 0.5
+    endloop
+  endfacet
+  facet normal 0.502104 0.372458 -0.780491
+    outer loop
+      vertex -1.2472 20.9166 1.5
+      vertex -1.15952 20.7984 1.5
+      vertex -2.28654 20.2222 0.5
+    endloop
+  endfacet
+  facet normal -0.37244 0.502114 -0.780494
+    outer loop
+      vertex 0.95159 20.5905 1.5
+      vertex 1.52782 19.4635 0.5
+      vertex 0.833355 20.5028 1.5
+    endloop
+  endfacet
+  facet normal 0.0917319 0.618382 -0.780506
+    outer loop
+      vertex -0.147025 20.2572 1.5
+      vertex -0.269547 19.0132 0.5
+      vertex -0.536498 19.0528 0.5
+    endloop
+  endfacet
+  facet normal 0.0305778 0.624403 -0.780504
+    outer loop
+      vertex 0 20.25 1.5
+      vertex 0 19 0.5
+      vertex -0.147025 20.2572 1.5
+    endloop
+  endfacet
+  facet normal 0.152029 -0.606385 -0.780502
+    outer loop
+      vertex -0.292635 23.2212 1.5
+      vertex -0.435427 23.1854 1.5
+      vertex -0.536498 24.4472 0.5
+    endloop
+  endfacet
+  facet normal 0.0917316 -0.618382 -0.780506
+    outer loop
+      vertex -0.147025 23.2428 1.5
+      vertex -0.292635 23.2212 1.5
+      vertex -0.536498 24.4472 0.5
+    endloop
+  endfacet
+  facet normal 0.21057 0.588615 -0.780508
+    outer loop
+      vertex -0.435427 20.3146 1.5
+      vertex -0.798283 19.1184 0.5
+      vertex -1.05238 19.2093 0.5
+    endloop
+  endfacet
+  facet normal 0.463271 0.419789 -0.780485
+    outer loop
+      vertex -1.15952 20.7984 1.5
+      vertex -1.06066 20.6893 1.5
+      vertex -1.94454 19.8055 0.5
+    endloop
+  endfacet
+  facet normal -0.321464 0.536174 -0.780499
+    outer loop
+      vertex 0.833355 20.5028 1.5
+      vertex 1.29634 19.3247 0.5
+      vertex 0.707094 20.4271 1.5
+    endloop
+  endfacet
+  facet normal -0.0917319 -0.618382 -0.780506
+    outer loop
+      vertex 0.269547 24.4868 0.5
+      vertex 0.536498 24.4472 0.5
+      vertex 0.147025 23.2428 1.5
+    endloop
+  endfacet
+  facet normal 0.0305777 -0.624403 -0.780504
+    outer loop
+      vertex 0 24.5 0.5
+      vertex -0.147025 23.2428 1.5
+      vertex -0.269547 24.4868 0.5
+    endloop
+  endfacet
+  facet normal -0.0917316 -0.618382 -0.780506
+    outer loop
+      vertex 0.536498 24.4472 0.5
+      vertex 0.292635 23.2212 1.5
+      vertex 0.147025 23.2428 1.5
+    endloop
+  endfacet
+  facet normal 0.565145 -0.267244 -0.780507
+    outer loop
+      vertex -1.32288 22.4571 1.5
+      vertex -1.38582 22.324 1.5
+      vertex -2.54067 22.8024 0.5
+    endloop
+  endfacet
+  facet normal 0.0917316 0.618382 -0.780506
+    outer loop
+      vertex -0.292635 20.2788 1.5
+      vertex -0.147025 20.2572 1.5
+      vertex -0.536498 19.0528 0.5
+    endloop
+  endfacet
+  facet normal 0.618391 -0.0917163 -0.780501
+    outer loop
+      vertex -2.69716 22.2865 0.5
+      vertex -1.49278 21.897 1.5
+      vertex -2.73676 22.0195 0.5
+    endloop
+  endfacet
+  facet normal 0.372311 -0.502191 -0.780506
+    outer loop
+      vertex -1.52782 24.0365 0.5
+      vertex -0.95159 22.9095 1.5
+      vertex -1.74458 23.8758 0.5
+    endloop
+  endfacet
+  facet normal -0.618385 0.0917384 -0.780503
+    outer loop
+      vertex 1.49278 21.603 1.5
+      vertex 2.69716 21.2135 0.5
+      vertex 1.47118 21.4574 1.5
+    endloop
+  endfacet
+  facet normal 0.151955 0.606396 -0.780509
+    outer loop
+      vertex -0.435427 20.3146 1.5
+      vertex -0.536498 19.0528 0.5
+      vertex -0.798283 19.1184 0.5
+    endloop
+  endfacet
+  facet normal 0.321492 0.53616 -0.780497
+    outer loop
+      vertex -0.833355 20.5028 1.5
+      vertex -1.29634 19.3247 0.5
+      vertex -1.52782 19.4635 0.5
+    endloop
+  endfacet
+  facet normal 0.152029 0.606385 -0.780502
+    outer loop
+      vertex -0.435427 20.3146 1.5
+      vertex -0.292635 20.2788 1.5
+      vertex -0.536498 19.0528 0.5
+    endloop
+  endfacet
+  facet normal 0.514213 0.857662 -0
+    outer loop
+      vertex -0.707094 -19.5729 0
+      vertex -0.833355 -19.4972 0.5
+      vertex -0.707094 -19.5729 0.5
+    endloop
+  endfacet
+  facet normal 0.514213 0.857662 0
+    outer loop
+      vertex -0.833355 -19.4972 0.5
+      vertex -0.707094 -19.5729 0
+      vertex -0.833355 -19.4972 0
+    endloop
+  endfacet
+  facet normal 0.803153 -0.595773 0
+    outer loop
+      vertex -1.2472 -17.4166 0.5
+      vertex -1.15952 -17.2984 0
+      vertex -1.15952 -17.2984 0.5
+    endloop
+  endfacet
+  facet normal 0.803153 -0.595773 0
+    outer loop
+      vertex -1.15952 -17.2984 0
+      vertex -1.2472 -17.4166 0.5
+      vertex -1.2472 -17.4166 0
+    endloop
+  endfacet
+  facet normal -0.989174 -0.146746 0
+    outer loop
+      vertex 1.49278 -18.103 0
+      vertex 1.47118 -17.9574 0.5
+      vertex 1.47118 -17.9574 0
+    endloop
+  endfacet
+  facet normal -0.989174 -0.146746 0
+    outer loop
+      vertex 1.47118 -17.9574 0.5
+      vertex 1.49278 -18.103 0
+      vertex 1.49278 -18.103 0.5
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490565 0
+    outer loop
+      vertex 1.5 -18.25 0
+      vertex 1.49278 -18.103 0.5
+      vertex 1.49278 -18.103 0
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490565 0
+    outer loop
+      vertex 1.49278 -18.103 0.5
+      vertex 1.5 -18.25 0
+      vertex 1.5 -18.25 0.5
+    endloop
+  endfacet
+  facet normal -0.970031 -0.242983 0
+    outer loop
+      vertex 1.47118 -17.9574 0
+      vertex 1.43541 -17.8146 0.5
+      vertex 1.43541 -17.8146 0
+    endloop
+  endfacet
+  facet normal -0.970031 -0.242983 0
+    outer loop
+      vertex 1.43541 -17.8146 0.5
+      vertex 1.47118 -17.9574 0
+      vertex 1.47118 -17.9574 0.5
+    endloop
+  endfacet
+  facet normal -0.941548 0.336879 0
+    outer loop
+      vertex 1.38582 -18.824 0
+      vertex 1.43541 -18.6854 0.5
+      vertex 1.43541 -18.6854 0
+    endloop
+  endfacet
+  facet normal -0.941548 0.336879 0
+    outer loop
+      vertex 1.43541 -18.6854 0.5
+      vertex 1.38582 -18.824 0
+      vertex 1.38582 -18.824 0.5
+    endloop
+  endfacet
+  facet normal 0.595747 -0.803172 0
+    outer loop
+      vertex -0.95159 -17.0905 0
+      vertex -0.833355 -17.0028 0.5
+      vertex -0.95159 -17.0905 0.5
+    endloop
+  endfacet
+  facet normal 0.595747 -0.803172 0
+    outer loop
+      vertex -0.833355 -17.0028 0.5
+      vertex -0.95159 -17.0905 0
+      vertex -0.833355 -17.0028 0
+    endloop
+  endfacet
+  facet normal -0.941548 -0.336879 0
+    outer loop
+      vertex 1.43541 -17.8146 0
+      vertex 1.38582 -17.676 0.5
+      vertex 1.38582 -17.676 0
+    endloop
+  endfacet
+  facet normal -0.941548 -0.336879 0
+    outer loop
+      vertex 1.38582 -17.676 0.5
+      vertex 1.43541 -17.8146 0
+      vertex 1.43541 -17.8146 0.5
+    endloop
+  endfacet
+  facet normal 0.989174 -0.146746 0
+    outer loop
+      vertex -1.49278 -18.103 0.5
+      vertex -1.47118 -17.9574 0
+      vertex -1.47118 -17.9574 0.5
+    endloop
+  endfacet
+  facet normal 0.989174 -0.146746 0
+    outer loop
+      vertex -1.47118 -17.9574 0
+      vertex -1.49278 -18.103 0.5
+      vertex -1.49278 -18.103 0
+    endloop
+  endfacet
+  facet normal -0.671353 -0.741138 0
+    outer loop
+      vertex 0.95159 -17.0905 0
+      vertex 1.06066 -17.1893 0.5
+      vertex 0.95159 -17.0905 0.5
+    endloop
+  endfacet
+  facet normal -0.671353 -0.741138 -0
+    outer loop
+      vertex 1.06066 -17.1893 0.5
+      vertex 0.95159 -17.0905 0
+      vertex 1.06066 -17.1893 0
+    endloop
+  endfacet
+  facet normal 0.0489126 0.998803 -0
+    outer loop
+      vertex 0 -19.75 0
+      vertex -0.147025 -19.7428 0.5
+      vertex 0 -19.75 0.5
+    endloop
+  endfacet
+  facet normal 0.0489126 0.998803 0
+    outer loop
+      vertex -0.147025 -19.7428 0.5
+      vertex 0 -19.75 0
+      vertex -0.147025 -19.7428 0
+    endloop
+  endfacet
+  facet normal 0.941548 -0.336879 0
+    outer loop
+      vertex -1.43541 -17.8146 0.5
+      vertex -1.38582 -17.676 0
+      vertex -1.38582 -17.676 0.5
+    endloop
+  endfacet
+  facet normal 0.941548 -0.336879 0
+    outer loop
+      vertex -1.38582 -17.676 0
+      vertex -1.43541 -17.8146 0.5
+      vertex -1.43541 -17.8146 0
+    endloop
+  endfacet
+  facet normal -0.0489126 -0.998803 0
+    outer loop
+      vertex 0 -16.75 0
+      vertex 0.147025 -16.7572 0.5
+      vertex 0 -16.75 0.5
+    endloop
+  endfacet
+  facet normal -0.0489126 -0.998803 -0
+    outer loop
+      vertex 0.147025 -16.7572 0.5
+      vertex 0 -16.75 0
+      vertex 0.147025 -16.7572 0
+    endloop
+  endfacet
+  facet normal 0.857792 -0.513996 0
+    outer loop
+      vertex -1.32288 -17.5429 0.5
+      vertex -1.2472 -17.4166 0
+      vertex -1.2472 -17.4166 0.5
+    endloop
+  endfacet
+  facet normal 0.857792 -0.513996 0
+    outer loop
+      vertex -1.2472 -17.4166 0
+      vertex -1.32288 -17.5429 0.5
+      vertex -1.32288 -17.5429 0
+    endloop
+  endfacet
+  facet normal 0.336945 -0.941524 0
+    outer loop
+      vertex -0.574024 -16.8642 0
+      vertex -0.435427 -16.8146 0.5
+      vertex -0.574024 -16.8642 0.5
+    endloop
+  endfacet
+  facet normal 0.336945 -0.941524 0
+    outer loop
+      vertex -0.435427 -16.8146 0.5
+      vertex -0.574024 -16.8642 0
+      vertex -0.435427 -16.8146 0
+    endloop
+  endfacet
+  facet normal 0.146736 -0.989176 0
+    outer loop
+      vertex -0.292635 -16.7788 0
+      vertex -0.147025 -16.7572 0.5
+      vertex -0.292635 -16.7788 0.5
+    endloop
+  endfacet
+  facet normal 0.146736 -0.989176 0
+    outer loop
+      vertex -0.147025 -16.7572 0.5
+      vertex -0.292635 -16.7788 0
+      vertex -0.147025 -16.7572 0
+    endloop
+  endfacet
+  facet normal -0.427347 -0.904088 0
+    outer loop
+      vertex 0.574024 -16.8642 0
+      vertex 0.707094 -16.9271 0.5
+      vertex 0.574024 -16.8642 0.5
+    endloop
+  endfacet
+  facet normal -0.427347 -0.904088 -0
+    outer loop
+      vertex 0.707094 -16.9271 0.5
+      vertex 0.574024 -16.8642 0
+      vertex 0.707094 -16.9271 0
+    endloop
+  endfacet
+  facet normal 0.671353 0.741138 -0
+    outer loop
+      vertex -0.95159 -19.4095 0
+      vertex -1.06066 -19.3107 0.5
+      vertex -0.95159 -19.4095 0.5
+    endloop
+  endfacet
+  facet normal 0.671353 0.741138 0
+    outer loop
+      vertex -1.06066 -19.3107 0.5
+      vertex -0.95159 -19.4095 0
+      vertex -1.06066 -19.3107 0
+    endloop
+  endfacet
+  facet normal -0.146736 0.989176 0
+    outer loop
+      vertex 0.292635 -19.7212 0
+      vertex 0.147025 -19.7428 0.5
+      vertex 0.292635 -19.7212 0.5
+    endloop
+  endfacet
+  facet normal -0.146736 0.989176 0
+    outer loop
+      vertex 0.147025 -19.7428 0.5
+      vertex 0.292635 -19.7212 0
+      vertex 0.147025 -19.7428 0
+    endloop
+  endfacet
+  facet normal -0.243188 -0.969979 0
+    outer loop
+      vertex 0.292635 -16.7788 0
+      vertex 0.435427 -16.8146 0.5
+      vertex 0.292635 -16.7788 0.5
+    endloop
+  endfacet
+  facet normal -0.243188 -0.969979 -0
+    outer loop
+      vertex 0.435427 -16.8146 0.5
+      vertex 0.292635 -16.7788 0
+      vertex 0.435427 -16.8146 0
+    endloop
+  endfacet
+  facet normal -0.803153 0.595773 0
+    outer loop
+      vertex 1.15952 -19.2016 0
+      vertex 1.2472 -19.0834 0.5
+      vertex 1.2472 -19.0834 0
+    endloop
+  endfacet
+  facet normal -0.803153 0.595773 0
+    outer loop
+      vertex 1.2472 -19.0834 0.5
+      vertex 1.15952 -19.2016 0
+      vertex 1.15952 -19.2016 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 0.803172 0
+    outer loop
+      vertex 0.95159 -19.4095 0
+      vertex 0.833355 -19.4972 0.5
+      vertex 0.95159 -19.4095 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 0.803172 0
+    outer loop
+      vertex 0.833355 -19.4972 0.5
+      vertex 0.95159 -19.4095 0
+      vertex 0.833355 -19.4972 0
+    endloop
+  endfacet
+  facet normal 0.514213 -0.857662 0
+    outer loop
+      vertex -0.833355 -17.0028 0
+      vertex -0.707094 -16.9271 0.5
+      vertex -0.833355 -17.0028 0.5
+    endloop
+  endfacet
+  facet normal 0.514213 -0.857662 0
+    outer loop
+      vertex -0.707094 -16.9271 0.5
+      vertex -0.833355 -17.0028 0
+      vertex -0.707094 -16.9271 0
+    endloop
+  endfacet
+  facet normal -0.989174 0.146746 0
+    outer loop
+      vertex 1.47118 -18.5426 0
+      vertex 1.49278 -18.397 0.5
+      vertex 1.49278 -18.397 0
+    endloop
+  endfacet
+  facet normal -0.989174 0.146746 0
+    outer loop
+      vertex 1.49278 -18.397 0.5
+      vertex 1.47118 -18.5426 0
+      vertex 1.47118 -18.5426 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 -0.803172 0
+    outer loop
+      vertex 0.833355 -17.0028 0
+      vertex 0.95159 -17.0905 0.5
+      vertex 0.833355 -17.0028 0.5
+    endloop
+  endfacet
+  facet normal -0.595747 -0.803172 -0
+    outer loop
+      vertex 0.95159 -17.0905 0.5
+      vertex 0.833355 -17.0028 0
+      vertex 0.95159 -17.0905 0
+    endloop
+  endfacet
+  facet normal -0.970031 0.242983 0
+    outer loop
+      vertex 1.43541 -18.6854 0
+      vertex 1.47118 -18.5426 0.5
+      vertex 1.47118 -18.5426 0
+    endloop
+  endfacet
+  facet normal -0.970031 0.242983 0
+    outer loop
+      vertex 1.47118 -18.5426 0.5
+      vertex 1.43541 -18.6854 0
+      vertex 1.43541 -18.6854 0.5
+    endloop
+  endfacet
+  facet normal -0.803153 -0.595773 0
+    outer loop
+      vertex 1.2472 -17.4166 0
+      vertex 1.15952 -17.2984 0.5
+      vertex 1.15952 -17.2984 0
+    endloop
+  endfacet
+  facet normal -0.803153 -0.595773 0
+    outer loop
+      vertex 1.15952 -17.2984 0.5
+      vertex 1.2472 -17.4166 0
+      vertex 1.2472 -17.4166 0.5
+    endloop
+  endfacet
+  facet normal -0.243188 0.969979 0
+    outer loop
+      vertex 0.435427 -19.6854 0
+      vertex 0.292635 -19.7212 0.5
+      vertex 0.435427 -19.6854 0.5
+    endloop
+  endfacet
+  facet normal -0.243188 0.969979 0
+    outer loop
+      vertex 0.292635 -19.7212 0.5
+      vertex 0.435427 -19.6854 0
+      vertex 0.292635 -19.7212 0
+    endloop
+  endfacet
+  facet normal -0.514213 -0.857662 0
+    outer loop
+      vertex 0.707094 -16.9271 0
+      vertex 0.833355 -17.0028 0.5
+      vertex 0.707094 -16.9271 0.5
+    endloop
+  endfacet
+  facet normal -0.514213 -0.857662 -0
+    outer loop
+      vertex 0.833355 -17.0028 0.5
+      vertex 0.707094 -16.9271 0
+      vertex 0.833355 -17.0028 0
+    endloop
+  endfacet
+  facet normal 0.243188 0.969979 -0
+    outer loop
+      vertex -0.292635 -19.7212 0
+      vertex -0.435427 -19.6854 0.5
+      vertex -0.292635 -19.7212 0.5
+    endloop
+  endfacet
+  facet normal 0.243188 0.969979 0
+    outer loop
+      vertex -0.435427 -19.6854 0.5
+      vertex -0.292635 -19.7212 0
+      vertex -0.435427 -19.6854 0
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490565 0
+    outer loop
+      vertex 1.49278 -18.397 0
+      vertex 1.5 -18.25 0.5
+      vertex 1.5 -18.25 0
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490565 0
+    outer loop
+      vertex 1.5 -18.25 0.5
+      vertex 1.49278 -18.397 0
+      vertex 1.49278 -18.397 0.5
+    endloop
+  endfacet
+  facet normal -0.857792 -0.513996 0
+    outer loop
+      vertex 1.32288 -17.5429 0
+      vertex 1.2472 -17.4166 0.5
+      vertex 1.2472 -17.4166 0
+    endloop
+  endfacet
+  facet normal -0.857792 -0.513996 0
+    outer loop
+      vertex 1.2472 -17.4166 0.5
+      vertex 1.32288 -17.5429 0
+      vertex 1.32288 -17.5429 0.5
+    endloop
+  endfacet
+  facet normal -0.741027 -0.671475 0
+    outer loop
+      vertex 1.15952 -17.2984 0
+      vertex 1.06066 -17.1893 0.5
+      vertex 1.06066 -17.1893 0
+    endloop
+  endfacet
+  facet normal -0.741027 -0.671475 0
+    outer loop
+      vertex 1.06066 -17.1893 0.5
+      vertex 1.15952 -17.2984 0
+      vertex 1.15952 -17.2984 0.5
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490565 0
+    outer loop
+      vertex -1.5 -18.25 0.5
+      vertex -1.49278 -18.103 0
+      vertex -1.49278 -18.103 0.5
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490565 0
+    outer loop
+      vertex -1.49278 -18.103 0
+      vertex -1.5 -18.25 0.5
+      vertex -1.5 -18.25 0
+    endloop
+  endfacet
+  facet normal -0.146736 -0.989176 0
+    outer loop
+      vertex 0.147025 -16.7572 0
+      vertex 0.292635 -16.7788 0.5
+      vertex 0.147025 -16.7572 0.5
+    endloop
+  endfacet
+  facet normal -0.146736 -0.989176 -0
+    outer loop
+      vertex 0.292635 -16.7788 0.5
+      vertex 0.147025 -16.7572 0
+      vertex 0.292635 -16.7788 0
+    endloop
+  endfacet
+  facet normal -0.336945 0.941524 0
+    outer loop
+      vertex 0.574024 -19.6358 0
+      vertex 0.435427 -19.6854 0.5
+      vertex 0.574024 -19.6358 0.5
+    endloop
+  endfacet
+  facet normal -0.336945 0.941524 0
+    outer loop
+      vertex 0.435427 -19.6854 0.5
+      vertex 0.574024 -19.6358 0
+      vertex 0.435427 -19.6854 0
+    endloop
+  endfacet
+  facet normal -0.0489126 0.998803 0
+    outer loop
+      vertex 0.147025 -19.7428 0
+      vertex 0 -19.75 0.5
+      vertex 0.147025 -19.7428 0.5
+    endloop
+  endfacet
+  facet normal -0.0489126 0.998803 0
+    outer loop
+      vertex 0 -19.75 0.5
+      vertex 0.147025 -19.7428 0
+      vertex 0 -19.75 0
+    endloop
+  endfacet
+  facet normal -0.857792 0.513996 0
+    outer loop
+      vertex 1.2472 -19.0834 0
+      vertex 1.32288 -18.9571 0.5
+      vertex 1.32288 -18.9571 0
+    endloop
+  endfacet
+  facet normal -0.857792 0.513996 0
+    outer loop
+      vertex 1.32288 -18.9571 0.5
+      vertex 1.2472 -19.0834 0
+      vertex 1.2472 -19.0834 0.5
+    endloop
+  endfacet
+  facet normal 0.857792 0.513996 0
+    outer loop
+      vertex -1.2472 -19.0834 0.5
+      vertex -1.32288 -18.9571 0
+      vertex -1.32288 -18.9571 0.5
+    endloop
+  endfacet
+  facet normal 0.857792 0.513996 0
+    outer loop
+      vertex -1.32288 -18.9571 0
+      vertex -1.2472 -19.0834 0.5
+      vertex -1.2472 -19.0834 0
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490565 0
+    outer loop
+      vertex -1.49278 -18.397 0.5
+      vertex -1.5 -18.25 0
+      vertex -1.5 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490565 0
+    outer loop
+      vertex -1.5 -18.25 0
+      vertex -1.49278 -18.397 0.5
+      vertex -1.49278 -18.397 0
+    endloop
+  endfacet
+  facet normal 0.741027 -0.671475 0
+    outer loop
+      vertex -1.15952 -17.2984 0.5
+      vertex -1.06066 -17.1893 0
+      vertex -1.06066 -17.1893 0.5
+    endloop
+  endfacet
+  facet normal 0.741027 -0.671475 0
+    outer loop
+      vertex -1.06066 -17.1893 0
+      vertex -1.15952 -17.2984 0.5
+      vertex -1.15952 -17.2984 0
+    endloop
+  endfacet
+  facet normal -0.741027 0.671475 0
+    outer loop
+      vertex 1.06066 -19.3107 0
+      vertex 1.15952 -19.2016 0.5
+      vertex 1.15952 -19.2016 0
+    endloop
+  endfacet
+  facet normal -0.741027 0.671475 0
+    outer loop
+      vertex 1.15952 -19.2016 0.5
+      vertex 1.06066 -19.3107 0
+      vertex 1.06066 -19.3107 0.5
+    endloop
+  endfacet
+  facet normal 0.0489126 -0.998803 0
+    outer loop
+      vertex -0.147025 -16.7572 0
+      vertex 0 -16.75 0.5
+      vertex -0.147025 -16.7572 0.5
+    endloop
+  endfacet
+  facet normal 0.0489126 -0.998803 0
+    outer loop
+      vertex 0 -16.75 0.5
+      vertex -0.147025 -16.7572 0
+      vertex 0 -16.75 0
+    endloop
+  endfacet
+  facet normal -0.90402 -0.427491 0
+    outer loop
+      vertex 1.38582 -17.676 0
+      vertex 1.32288 -17.5429 0.5
+      vertex 1.32288 -17.5429 0
+    endloop
+  endfacet
+  facet normal -0.90402 -0.427491 0
+    outer loop
+      vertex 1.32288 -17.5429 0.5
+      vertex 1.38582 -17.676 0
+      vertex 1.38582 -17.676 0.5
+    endloop
+  endfacet
+  facet normal 0.90402 -0.427491 0
+    outer loop
+      vertex -1.38582 -17.676 0.5
+      vertex -1.32288 -17.5429 0
+      vertex -1.32288 -17.5429 0.5
+    endloop
+  endfacet
+  facet normal 0.90402 -0.427491 0
+    outer loop
+      vertex -1.32288 -17.5429 0
+      vertex -1.38582 -17.676 0.5
+      vertex -1.38582 -17.676 0
+    endloop
+  endfacet
+  facet normal 0.671353 -0.741138 0
+    outer loop
+      vertex -1.06066 -17.1893 0
+      vertex -0.95159 -17.0905 0.5
+      vertex -1.06066 -17.1893 0.5
+    endloop
+  endfacet
+  facet normal 0.671353 -0.741138 0
+    outer loop
+      vertex -0.95159 -17.0905 0.5
+      vertex -1.06066 -17.1893 0
+      vertex -0.95159 -17.0905 0
+    endloop
+  endfacet
+  facet normal -0.336945 -0.941524 0
+    outer loop
+      vertex 0.435427 -16.8146 0
+      vertex 0.574024 -16.8642 0.5
+      vertex 0.435427 -16.8146 0.5
+    endloop
+  endfacet
+  facet normal -0.336945 -0.941524 -0
+    outer loop
+      vertex 0.574024 -16.8642 0.5
+      vertex 0.435427 -16.8146 0
+      vertex 0.574024 -16.8642 0
+    endloop
+  endfacet
+  facet normal -0.427347 0.904088 0
+    outer loop
+      vertex 0.707094 -19.5729 0
+      vertex 0.574024 -19.6358 0.5
+      vertex 0.707094 -19.5729 0.5
+    endloop
+  endfacet
+  facet normal -0.427347 0.904088 0
+    outer loop
+      vertex 0.574024 -19.6358 0.5
+      vertex 0.707094 -19.5729 0
+      vertex 0.574024 -19.6358 0
+    endloop
+  endfacet
+  facet normal 0.243188 -0.969979 0
+    outer loop
+      vertex -0.435427 -16.8146 0
+      vertex -0.292635 -16.7788 0.5
+      vertex -0.435427 -16.8146 0.5
+    endloop
+  endfacet
+  facet normal 0.243188 -0.969979 0
+    outer loop
+      vertex -0.292635 -16.7788 0.5
+      vertex -0.435427 -16.8146 0
+      vertex -0.292635 -16.7788 0
+    endloop
+  endfacet
+  facet normal 0.970031 0.242983 0
+    outer loop
+      vertex -1.43541 -18.6854 0.5
+      vertex -1.47118 -18.5426 0
+      vertex -1.47118 -18.5426 0.5
+    endloop
+  endfacet
+  facet normal 0.970031 0.242983 0
+    outer loop
+      vertex -1.47118 -18.5426 0
+      vertex -1.43541 -18.6854 0.5
+      vertex -1.43541 -18.6854 0
+    endloop
+  endfacet
+  facet normal 0.970031 -0.242983 0
+    outer loop
+      vertex -1.47118 -17.9574 0.5
+      vertex -1.43541 -17.8146 0
+      vertex -1.43541 -17.8146 0.5
+    endloop
+  endfacet
+  facet normal 0.970031 -0.242983 0
+    outer loop
+      vertex -1.43541 -17.8146 0
+      vertex -1.47118 -17.9574 0.5
+      vertex -1.47118 -17.9574 0
+    endloop
+  endfacet
+  facet normal 0.941548 0.336879 0
+    outer loop
+      vertex -1.38582 -18.824 0.5
+      vertex -1.43541 -18.6854 0
+      vertex -1.43541 -18.6854 0.5
+    endloop
+  endfacet
+  facet normal 0.941548 0.336879 0
+    outer loop
+      vertex -1.43541 -18.6854 0
+      vertex -1.38582 -18.824 0.5
+      vertex -1.38582 -18.824 0
+    endloop
+  endfacet
+  facet normal 0.741027 0.671475 0
+    outer loop
+      vertex -1.06066 -19.3107 0.5
+      vertex -1.15952 -19.2016 0
+      vertex -1.15952 -19.2016 0.5
+    endloop
+  endfacet
+  facet normal 0.741027 0.671475 0
+    outer loop
+      vertex -1.15952 -19.2016 0
+      vertex -1.06066 -19.3107 0.5
+      vertex -1.06066 -19.3107 0
+    endloop
+  endfacet
+  facet normal 0.803153 0.595773 0
+    outer loop
+      vertex -1.15952 -19.2016 0.5
+      vertex -1.2472 -19.0834 0
+      vertex -1.2472 -19.0834 0.5
+    endloop
+  endfacet
+  facet normal 0.803153 0.595773 0
+    outer loop
+      vertex -1.2472 -19.0834 0
+      vertex -1.15952 -19.2016 0.5
+      vertex -1.15952 -19.2016 0
+    endloop
+  endfacet
+  facet normal 0.427347 0.904088 -0
+    outer loop
+      vertex -0.574024 -19.6358 0
+      vertex -0.707094 -19.5729 0.5
+      vertex -0.574024 -19.6358 0.5
+    endloop
+  endfacet
+  facet normal 0.427347 0.904088 0
+    outer loop
+      vertex -0.707094 -19.5729 0.5
+      vertex -0.574024 -19.6358 0
+      vertex -0.707094 -19.5729 0
+    endloop
+  endfacet
+  facet normal 0.989174 0.146746 0
+    outer loop
+      vertex -1.47118 -18.5426 0.5
+      vertex -1.49278 -18.397 0
+      vertex -1.49278 -18.397 0.5
+    endloop
+  endfacet
+  facet normal 0.989174 0.146746 0
+    outer loop
+      vertex -1.49278 -18.397 0
+      vertex -1.47118 -18.5426 0.5
+      vertex -1.47118 -18.5426 0
+    endloop
+  endfacet
+  facet normal 0.336945 0.941524 -0
+    outer loop
+      vertex -0.435427 -19.6854 0
+      vertex -0.574024 -19.6358 0.5
+      vertex -0.435427 -19.6854 0.5
+    endloop
+  endfacet
+  facet normal 0.336945 0.941524 0
+    outer loop
+      vertex -0.574024 -19.6358 0.5
+      vertex -0.435427 -19.6854 0
+      vertex -0.574024 -19.6358 0
+    endloop
+  endfacet
+  facet normal -0.514213 0.857662 0
+    outer loop
+      vertex 0.833355 -19.4972 0
+      vertex 0.707094 -19.5729 0.5
+      vertex 0.833355 -19.4972 0.5
+    endloop
+  endfacet
+  facet normal -0.514213 0.857662 0
+    outer loop
+      vertex 0.707094 -19.5729 0.5
+      vertex 0.833355 -19.4972 0
+      vertex 0.707094 -19.5729 0
+    endloop
+  endfacet
+  facet normal -0.90402 0.427491 0
+    outer loop
+      vertex 1.32288 -18.9571 0
+      vertex 1.38582 -18.824 0.5
+      vertex 1.38582 -18.824 0
+    endloop
+  endfacet
+  facet normal -0.90402 0.427491 0
+    outer loop
+      vertex 1.38582 -18.824 0.5
+      vertex 1.32288 -18.9571 0
+      vertex 1.32288 -18.9571 0.5
+    endloop
+  endfacet
+  facet normal -0.671353 0.741138 0
+    outer loop
+      vertex 1.06066 -19.3107 0
+      vertex 0.95159 -19.4095 0.5
+      vertex 1.06066 -19.3107 0.5
+    endloop
+  endfacet
+  facet normal -0.671353 0.741138 0
+    outer loop
+      vertex 0.95159 -19.4095 0.5
+      vertex 1.06066 -19.3107 0
+      vertex 0.95159 -19.4095 0
+    endloop
+  endfacet
+  facet normal 0.90402 0.427491 0
+    outer loop
+      vertex -1.32288 -18.9571 0.5
+      vertex -1.38582 -18.824 0
+      vertex -1.38582 -18.824 0.5
+    endloop
+  endfacet
+  facet normal 0.90402 0.427491 0
+    outer loop
+      vertex -1.38582 -18.824 0
+      vertex -1.32288 -18.9571 0.5
+      vertex -1.32288 -18.9571 0
+    endloop
+  endfacet
+  facet normal 0.427347 -0.904088 0
+    outer loop
+      vertex -0.707094 -16.9271 0
+      vertex -0.574024 -16.8642 0.5
+      vertex -0.707094 -16.9271 0.5
+    endloop
+  endfacet
+  facet normal 0.427347 -0.904088 0
+    outer loop
+      vertex -0.574024 -16.8642 0.5
+      vertex -0.707094 -16.9271 0
+      vertex -0.574024 -16.8642 0
+    endloop
+  endfacet
+  facet normal 0.146736 0.989176 -0
+    outer loop
+      vertex -0.147025 -19.7428 0
+      vertex -0.292635 -19.7212 0.5
+      vertex -0.147025 -19.7428 0.5
+    endloop
+  endfacet
+  facet normal 0.146736 0.989176 0
+    outer loop
+      vertex -0.292635 -19.7212 0.5
+      vertex -0.147025 -19.7428 0
+      vertex -0.292635 -19.7212 0
+    endloop
+  endfacet
+  facet normal 0.595747 0.803172 -0
+    outer loop
+      vertex -0.833355 -19.4972 0
+      vertex -0.95159 -19.4095 0.5
+      vertex -0.833355 -19.4972 0.5
+    endloop
+  endfacet
+  facet normal 0.595747 0.803172 0
+    outer loop
+      vertex -0.95159 -19.4095 0.5
+      vertex -0.833355 -19.4972 0
+      vertex -0.95159 -19.4095 0
+    endloop
+  endfacet
+  facet normal -0.463271 0.419789 -0.780485
+    outer loop
+      vertex 1.15952 -19.2016 1.5
+      vertex 1.94454 -20.1945 0.5
+      vertex 1.06066 -19.3107 1.5
+    endloop
+  endfacet
+  facet normal -0.152029 0.606385 -0.780502
+    outer loop
+      vertex 0.435427 -19.6854 1.5
+      vertex 0.536498 -20.9472 0.5
+      vertex 0.292635 -19.7212 1.5
+    endloop
+  endfacet
+  facet normal -0.624401 -0.0306679 -0.780502
+    outer loop
+      vertex 2.75 -18.25 0.5
+      vertex 1.5 -18.25 1.5
+      vertex 1.49278 -18.103 1.5
+    endloop
+  endfacet
+  facet normal -0.624402 -0.0306756 -0.780501
+    outer loop
+      vertex 2.73676 -17.9805 0.5
+      vertex 2.75 -18.25 0.5
+      vertex 1.49278 -18.103 1.5
+    endloop
+  endfacet
+  facet normal 0.321464 -0.536174 -0.780499
+    outer loop
+      vertex -0.707094 -16.9271 1.5
+      vertex -0.833355 -17.0028 1.5
+      vertex -1.29634 -15.8247 0.5
+    endloop
+  endfacet
+  facet normal -0.267317 0.565118 -0.780502
+    outer loop
+      vertex 1.29634 -20.6753 0.5
+      vertex 1.05238 -20.7907 0.5
+      vertex 0.707094 -19.5729 1.5
+    endloop
+  endfacet
+  facet normal 0.624402 -0.0306756 -0.780501
+    outer loop
+      vertex -2.73676 -17.9805 0.5
+      vertex -1.49278 -18.103 1.5
+      vertex -2.75 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.5 -18.25 0.5
+      vertex 2.75 -18.25 0.5
+      vertex 2.73676 -17.9805 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.49278 -18.103 0.5
+      vertex 2.73676 -17.9805 0.5
+      vertex 2.69716 -17.7135 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.75 -18.25 0.5
+      vertex 1.5 -18.25 0.5
+      vertex 2.73676 -18.5195 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.47118 -17.9574 0.5
+      vertex 2.69716 -17.7135 0.5
+      vertex 2.63159 -17.4517 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49278 -18.397 0.5
+      vertex 2.73676 -18.5195 0.5
+      vertex 1.5 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.43541 -17.8146 0.5
+      vertex 2.63159 -17.4517 0.5
+      vertex 2.54067 -17.1976 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.73676 -18.5195 0.5
+      vertex 1.49278 -18.397 0.5
+      vertex 2.69716 -18.7865 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.38582 -17.676 0.5
+      vertex 2.54067 -17.1976 0.5
+      vertex 2.42528 -16.9537 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.47118 -18.5426 0.5
+      vertex 2.69716 -18.7865 0.5
+      vertex 1.49278 -18.397 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.32288 -17.5429 0.5
+      vertex 2.42528 -16.9537 0.5
+      vertex 2.28654 -16.7222 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.69716 -18.7865 0.5
+      vertex 1.47118 -18.5426 0.5
+      vertex 2.63159 -19.0483 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.2472 -17.4166 0.5
+      vertex 2.28654 -16.7222 0.5
+      vertex 2.12578 -16.5054 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.43541 -18.6854 0.5
+      vertex 2.63159 -19.0483 0.5
+      vertex 1.47118 -18.5426 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.15952 -17.2984 0.5
+      vertex 2.12578 -16.5054 0.5
+      vertex 1.94454 -16.3055 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.63159 -19.0483 0.5
+      vertex 1.43541 -18.6854 0.5
+      vertex 2.54067 -19.3024 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.06066 -17.1893 0.5
+      vertex 1.94454 -16.3055 0.5
+      vertex 1.74458 -16.1242 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.38582 -18.824 0.5
+      vertex 2.54067 -19.3024 0.5
+      vertex 1.43541 -18.6854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.95159 -17.0905 0.5
+      vertex 1.74458 -16.1242 0.5
+      vertex 1.52782 -15.9635 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54067 -19.3024 0.5
+      vertex 1.38582 -18.824 0.5
+      vertex 2.42528 -19.5463 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.32288 -18.9571 0.5
+      vertex 2.42528 -19.5463 0.5
+      vertex 1.38582 -18.824 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.73676 -17.9805 0.5
+      vertex 1.49278 -18.103 0.5
+      vertex 1.5 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.69716 -17.7135 0.5
+      vertex 1.47118 -17.9574 0.5
+      vertex 1.49278 -18.103 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.63159 -17.4517 0.5
+      vertex 1.43541 -17.8146 0.5
+      vertex 1.47118 -17.9574 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54067 -17.1976 0.5
+      vertex 1.38582 -17.676 0.5
+      vertex 1.43541 -17.8146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.42528 -16.9537 0.5
+      vertex 1.32288 -17.5429 0.5
+      vertex 1.38582 -17.676 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.833355 -17.0028 0.5
+      vertex 1.52782 -15.9635 0.5
+      vertex 1.29634 -15.8247 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.28654 -16.7222 0.5
+      vertex 1.2472 -17.4166 0.5
+      vertex 1.32288 -17.5429 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.12578 -16.5054 0.5
+      vertex 1.15952 -17.2984 0.5
+      vertex 1.2472 -17.4166 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.94454 -16.3055 0.5
+      vertex 1.06066 -17.1893 0.5
+      vertex 1.15952 -17.2984 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.707094 -16.9271 0.5
+      vertex 1.29634 -15.8247 0.5
+      vertex 1.05238 -15.7093 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.74458 -16.1242 0.5
+      vertex 0.95159 -17.0905 0.5
+      vertex 1.06066 -17.1893 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.52782 -15.9635 0.5
+      vertex 0.833355 -17.0028 0.5
+      vertex 0.95159 -17.0905 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.574024 -16.8642 0.5
+      vertex 1.05238 -15.7093 0.5
+      vertex 0.798283 -15.6184 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.29634 -15.8247 0.5
+      vertex 0.707094 -16.9271 0.5
+      vertex 0.833355 -17.0028 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.05238 -15.7093 0.5
+      vertex 0.574024 -16.8642 0.5
+      vertex 0.707094 -16.9271 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.435427 -16.8146 0.5
+      vertex 0.798283 -15.6184 0.5
+      vertex 0.536498 -15.5528 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.798283 -15.6184 0.5
+      vertex 0.435427 -16.8146 0.5
+      vertex 0.574024 -16.8642 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.536498 -15.5528 0.5
+      vertex 0.292635 -16.7788 0.5
+      vertex 0.435427 -16.8146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.269547 -15.5132 0.5
+      vertex 0.292635 -16.7788 0.5
+      vertex 0.536498 -15.5528 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.269547 -15.5132 0.5
+      vertex 0.147025 -16.7572 0.5
+      vertex 0.292635 -16.7788 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -15.5 0.5
+      vertex 0.147025 -16.7572 0.5
+      vertex 0.269547 -15.5132 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -15.5 0.5
+      vertex 0 -16.75 0.5
+      vertex 0.147025 -16.7572 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -15.5 0.5
+      vertex -0.147025 -16.7572 0.5
+      vertex 0 -16.75 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.269547 -15.5132 0.5
+      vertex -0.147025 -16.7572 0.5
+      vertex 0 -15.5 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.269547 -15.5132 0.5
+      vertex -0.292635 -16.7788 0.5
+      vertex -0.147025 -16.7572 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.536498 -15.5528 0.5
+      vertex -0.292635 -16.7788 0.5
+      vertex -0.269547 -15.5132 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 -16.7788 0.5
+      vertex -0.536498 -15.5528 0.5
+      vertex -0.435427 -16.8146 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.798283 -15.6184 0.5
+      vertex -0.435427 -16.8146 0.5
+      vertex -0.536498 -15.5528 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 -16.8146 0.5
+      vertex -0.798283 -15.6184 0.5
+      vertex -0.574024 -16.8642 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.05238 -15.7093 0.5
+      vertex -0.574024 -16.8642 0.5
+      vertex -0.798283 -15.6184 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.574024 -16.8642 0.5
+      vertex -1.05238 -15.7093 0.5
+      vertex -0.707094 -16.9271 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.29634 -15.8247 0.5
+      vertex -0.707094 -16.9271 0.5
+      vertex -1.05238 -15.7093 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 -16.9271 0.5
+      vertex -1.29634 -15.8247 0.5
+      vertex -0.833355 -17.0028 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.52782 -15.9635 0.5
+      vertex -0.833355 -17.0028 0.5
+      vertex -1.29634 -15.8247 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.833355 -17.0028 0.5
+      vertex -1.52782 -15.9635 0.5
+      vertex -0.95159 -17.0905 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.74458 -16.1242 0.5
+      vertex -0.95159 -17.0905 0.5
+      vertex -1.52782 -15.9635 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.95159 -17.0905 0.5
+      vertex -1.74458 -16.1242 0.5
+      vertex -1.06066 -17.1893 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.94454 -16.3055 0.5
+      vertex -1.06066 -17.1893 0.5
+      vertex -1.74458 -16.1242 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 -17.1893 0.5
+      vertex -1.94454 -16.3055 0.5
+      vertex -1.15952 -17.2984 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.12578 -16.5054 0.5
+      vertex -1.15952 -17.2984 0.5
+      vertex -1.94454 -16.3055 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15952 -17.2984 0.5
+      vertex -2.12578 -16.5054 0.5
+      vertex -1.2472 -17.4166 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.28654 -16.7222 0.5
+      vertex -1.2472 -17.4166 0.5
+      vertex -2.12578 -16.5054 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.42528 -16.9537 0.5
+      vertex -1.32288 -17.5429 0.5
+      vertex -2.28654 -16.7222 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2472 -17.4166 0.5
+      vertex -2.28654 -16.7222 0.5
+      vertex -1.32288 -17.5429 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.42528 -19.5463 0.5
+      vertex 1.32288 -18.9571 0.5
+      vertex 2.28654 -19.7778 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.2472 -19.0834 0.5
+      vertex 2.28654 -19.7778 0.5
+      vertex 1.32288 -18.9571 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.28654 -19.7778 0.5
+      vertex 1.2472 -19.0834 0.5
+      vertex 2.12578 -19.9946 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.15952 -19.2016 0.5
+      vertex 2.12578 -19.9946 0.5
+      vertex 1.2472 -19.0834 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.12578 -19.9946 0.5
+      vertex 1.15952 -19.2016 0.5
+      vertex 1.94454 -20.1945 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.06066 -19.3107 0.5
+      vertex 1.94454 -20.1945 0.5
+      vertex 1.15952 -19.2016 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.94454 -20.1945 0.5
+      vertex 1.06066 -19.3107 0.5
+      vertex 1.74458 -20.3758 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.95159 -19.4095 0.5
+      vertex 1.74458 -20.3758 0.5
+      vertex 1.06066 -19.3107 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.74458 -20.3758 0.5
+      vertex 0.95159 -19.4095 0.5
+      vertex 1.52782 -20.5365 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.833355 -19.4972 0.5
+      vertex 1.52782 -20.5365 0.5
+      vertex 0.95159 -19.4095 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.52782 -20.5365 0.5
+      vertex 0.833355 -19.4972 0.5
+      vertex 1.29634 -20.6753 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.707094 -19.5729 0.5
+      vertex 1.29634 -20.6753 0.5
+      vertex 0.833355 -19.4972 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.29634 -20.6753 0.5
+      vertex 0.707094 -19.5729 0.5
+      vertex 1.05238 -20.7907 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.574024 -19.6358 0.5
+      vertex 1.05238 -20.7907 0.5
+      vertex 0.707094 -19.5729 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.05238 -20.7907 0.5
+      vertex 0.574024 -19.6358 0.5
+      vertex 0.798283 -20.8816 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.435427 -19.6854 0.5
+      vertex 0.798283 -20.8816 0.5
+      vertex 0.574024 -19.6358 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.798283 -20.8816 0.5
+      vertex 0.435427 -19.6854 0.5
+      vertex 0.536498 -20.9472 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.292635 -19.7212 0.5
+      vertex 0.536498 -20.9472 0.5
+      vertex 0.435427 -19.6854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.292635 -19.7212 0.5
+      vertex 0.269547 -20.9868 0.5
+      vertex 0.536498 -20.9472 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.147025 -19.7428 0.5
+      vertex 0.269547 -20.9868 0.5
+      vertex 0.292635 -19.7212 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -19.75 0.5
+      vertex 0.269547 -20.9868 0.5
+      vertex 0.147025 -19.7428 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -19.75 0.5
+      vertex 0 -21 0.5
+      vertex 0.269547 -20.9868 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.147025 -19.7428 0.5
+      vertex 0 -21 0.5
+      vertex 0 -19.75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.147025 -19.7428 0.5
+      vertex -0.269547 -20.9868 0.5
+      vertex 0 -21 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 -19.7212 0.5
+      vertex -0.269547 -20.9868 0.5
+      vertex -0.147025 -19.7428 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.536498 -20.9472 0.5
+      vertex -0.292635 -19.7212 0.5
+      vertex -0.435427 -19.6854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.292635 -19.7212 0.5
+      vertex -0.536498 -20.9472 0.5
+      vertex -0.269547 -20.9868 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.798283 -20.8816 0.5
+      vertex -0.435427 -19.6854 0.5
+      vertex -0.574024 -19.6358 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.05238 -20.7907 0.5
+      vertex -0.574024 -19.6358 0.5
+      vertex -0.707094 -19.5729 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.435427 -19.6854 0.5
+      vertex -0.798283 -20.8816 0.5
+      vertex -0.536498 -20.9472 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.29634 -20.6753 0.5
+      vertex -0.707094 -19.5729 0.5
+      vertex -0.833355 -19.4972 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.52782 -20.5365 0.5
+      vertex -0.833355 -19.4972 0.5
+      vertex -0.95159 -19.4095 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.574024 -19.6358 0.5
+      vertex -1.05238 -20.7907 0.5
+      vertex -0.798283 -20.8816 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.74458 -20.3758 0.5
+      vertex -0.95159 -19.4095 0.5
+      vertex -1.06066 -19.3107 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.94454 -20.1945 0.5
+      vertex -1.06066 -19.3107 0.5
+      vertex -1.15952 -19.2016 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.12578 -19.9946 0.5
+      vertex -1.15952 -19.2016 0.5
+      vertex -1.2472 -19.0834 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.707094 -19.5729 0.5
+      vertex -1.29634 -20.6753 0.5
+      vertex -1.05238 -20.7907 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.28654 -19.7778 0.5
+      vertex -1.2472 -19.0834 0.5
+      vertex -1.32288 -18.9571 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.42528 -19.5463 0.5
+      vertex -1.32288 -18.9571 0.5
+      vertex -1.38582 -18.824 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.54067 -19.3024 0.5
+      vertex -1.38582 -18.824 0.5
+      vertex -1.43541 -18.6854 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.63159 -19.0483 0.5
+      vertex -1.43541 -18.6854 0.5
+      vertex -1.47118 -18.5426 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.69716 -18.7865 0.5
+      vertex -1.47118 -18.5426 0.5
+      vertex -1.49278 -18.397 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.833355 -19.4972 0.5
+      vertex -1.52782 -20.5365 0.5
+      vertex -1.29634 -20.6753 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.73676 -18.5195 0.5
+      vertex -1.49278 -18.397 0.5
+      vertex -1.5 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.32288 -17.5429 0.5
+      vertex -2.42528 -16.9537 0.5
+      vertex -1.38582 -17.676 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.54067 -17.1976 0.5
+      vertex -1.38582 -17.676 0.5
+      vertex -2.42528 -16.9537 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.95159 -19.4095 0.5
+      vertex -1.74458 -20.3758 0.5
+      vertex -1.52782 -20.5365 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 -17.676 0.5
+      vertex -2.54067 -17.1976 0.5
+      vertex -1.43541 -17.8146 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 -19.3107 0.5
+      vertex -1.94454 -20.1945 0.5
+      vertex -1.74458 -20.3758 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.63159 -17.4517 0.5
+      vertex -1.43541 -17.8146 0.5
+      vertex -2.54067 -17.1976 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15952 -19.2016 0.5
+      vertex -2.12578 -19.9946 0.5
+      vertex -1.94454 -20.1945 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 -17.8146 0.5
+      vertex -2.63159 -17.4517 0.5
+      vertex -1.47118 -17.9574 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2472 -19.0834 0.5
+      vertex -2.28654 -19.7778 0.5
+      vertex -2.12578 -19.9946 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.69716 -17.7135 0.5
+      vertex -1.47118 -17.9574 0.5
+      vertex -2.63159 -17.4517 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.32288 -18.9571 0.5
+      vertex -2.42528 -19.5463 0.5
+      vertex -2.28654 -19.7778 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 -17.9574 0.5
+      vertex -2.69716 -17.7135 0.5
+      vertex -1.49278 -18.103 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.38582 -18.824 0.5
+      vertex -2.54067 -19.3024 0.5
+      vertex -2.42528 -19.5463 0.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.73676 -17.9805 0.5
+      vertex -1.49278 -18.103 0.5
+      vertex -2.69716 -17.7135 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.43541 -18.6854 0.5
+      vertex -2.63159 -19.0483 0.5
+      vertex -2.54067 -19.3024 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 -18.103 0.5
+      vertex -2.73676 -17.9805 0.5
+      vertex -1.5 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47118 -18.5426 0.5
+      vertex -2.69716 -18.7865 0.5
+      vertex -2.63159 -19.0483 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.75 -18.25 0.5
+      vertex -1.5 -18.25 0.5
+      vertex -2.73676 -17.9805 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49278 -18.397 0.5
+      vertex -2.73676 -18.5195 0.5
+      vertex -2.69716 -18.7865 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.5 -18.25 0.5
+      vertex -2.75 -18.25 0.5
+      vertex -2.73676 -18.5195 0.5
+    endloop
+  endfacet
+  facet normal 0.267317 0.565118 -0.780502
+    outer loop
+      vertex -0.707094 -19.5729 1.5
+      vertex -1.05238 -20.7907 0.5
+      vertex -1.29634 -20.6753 0.5
+    endloop
+  endfacet
+  facet normal 0.26715 -0.565177 -0.780516
+    outer loop
+      vertex -0.574024 -16.8642 1.5
+      vertex -0.707094 -16.9271 1.5
+      vertex -1.05238 -15.7093 0.5
+    endloop
+  endfacet
+  facet normal -0.0305777 0.624403 -0.780504
+    outer loop
+      vertex 0.147025 -19.7428 1.5
+      vertex 0.269547 -20.9868 0.5
+      vertex 0 -21 0.5
+    endloop
+  endfacet
+  facet normal -0.21057 -0.588615 -0.780508
+    outer loop
+      vertex 0.798283 -15.6184 0.5
+      vertex 1.05238 -15.7093 0.5
+      vertex 0.435427 -16.8146 1.5
+    endloop
+  endfacet
+  facet normal -0.588604 -0.210609 -0.780506
+    outer loop
+      vertex 2.54067 -17.1976 0.5
+      vertex 2.63159 -17.4517 0.5
+      vertex 1.43541 -17.8146 1.5
+    endloop
+  endfacet
+  facet normal 0.151955 -0.606396 -0.780509
+    outer loop
+      vertex -0.536498 -15.5528 0.5
+      vertex -0.435427 -16.8146 1.5
+      vertex -0.798283 -15.6184 0.5
+    endloop
+  endfacet
+  facet normal 0.565106 -0.267354 -0.780498
+    outer loop
+      vertex -2.42528 -16.9537 0.5
+      vertex -1.32288 -17.5429 1.5
+      vertex -2.54067 -17.1976 0.5
+    endloop
+  endfacet
+  facet normal 0.502162 0.37236 -0.780501
+    outer loop
+      vertex -1.15952 -19.2016 1.5
+      vertex -2.12578 -19.9946 0.5
+      vertex -2.28654 -19.7778 0.5
+    endloop
+  endfacet
+  facet normal 0.502162 -0.37236 -0.780501
+    outer loop
+      vertex -2.12578 -16.5054 0.5
+      vertex -1.15952 -17.2984 1.5
+      vertex -2.28654 -16.7222 0.5
+    endloop
+  endfacet
+  facet normal -0.46314 -0.419907 -0.7805
+    outer loop
+      vertex 1.94454 -16.3055 0.5
+      vertex 2.12578 -16.5054 0.5
+      vertex 1.15952 -17.2984 1.5
+    endloop
+  endfacet
+  facet normal 0.606419 0.151883 -0.780505
+    outer loop
+      vertex -1.43541 -18.6854 1.5
+      vertex -2.63159 -19.0483 0.5
+      vertex -2.69716 -18.7865 0.5
+    endloop
+  endfacet
+  facet normal -0.618385 -0.0917384 -0.780503
+    outer loop
+      vertex 2.69716 -17.7135 0.5
+      vertex 1.49278 -18.103 1.5
+      vertex 1.47118 -17.9574 1.5
+    endloop
+  endfacet
+  facet normal -0.618391 0.0917163 -0.780501
+    outer loop
+      vertex 2.73676 -18.5195 0.5
+      vertex 2.69716 -18.7865 0.5
+      vertex 1.49278 -18.397 1.5
+    endloop
+  endfacet
+  facet normal -0.536257 -0.32133 -0.780497
+    outer loop
+      vertex 2.42528 -16.9537 0.5
+      vertex 1.32288 -17.5429 1.5
+      vertex 1.2472 -17.4166 1.5
+    endloop
+  endfacet
+  facet normal 0.618391 0.0917163 -0.780501
+    outer loop
+      vertex -1.49278 -18.397 1.5
+      vertex -2.69716 -18.7865 0.5
+      vertex -2.73676 -18.5195 0.5
+    endloop
+  endfacet
+  facet normal -0.463271 -0.419789 -0.780485
+    outer loop
+      vertex 1.94454 -16.3055 0.5
+      vertex 1.15952 -17.2984 1.5
+      vertex 1.06066 -17.1893 1.5
+    endloop
+  endfacet
+  facet normal -0.565145 -0.267244 -0.780507
+    outer loop
+      vertex 2.54067 -17.1976 0.5
+      vertex 1.38582 -17.676 1.5
+      vertex 1.32288 -17.5429 1.5
+    endloop
+  endfacet
+  facet normal -0.210637 0.588583 -0.780514
+    outer loop
+      vertex 0.574024 -19.6358 1.5
+      vertex 1.05238 -20.7907 0.5
+      vertex 0.435427 -19.6854 1.5
+    endloop
+  endfacet
+  facet normal -0.210637 -0.588583 -0.780514
+    outer loop
+      vertex 1.05238 -15.7093 0.5
+      vertex 0.574024 -16.8642 1.5
+      vertex 0.435427 -16.8146 1.5
+    endloop
+  endfacet
+  facet normal 0.624402 0.0306756 -0.780501
+    outer loop
+      vertex -1.49278 -18.397 1.5
+      vertex -2.73676 -18.5195 0.5
+      vertex -2.75 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0.321464 0.536174 -0.780499
+    outer loop
+      vertex -0.833355 -19.4972 1.5
+      vertex -0.707094 -19.5729 1.5
+      vertex -1.29634 -20.6753 0.5
+    endloop
+  endfacet
+  facet normal 0.0305778 -0.624403 -0.780504
+    outer loop
+      vertex 0 -15.5 0.5
+      vertex 0 -16.75 1.5
+      vertex -0.147025 -16.7572 1.5
+    endloop
+  endfacet
+  facet normal 0.419716 0.463344 -0.780481
+    outer loop
+      vertex -1.06066 -19.3107 1.5
+      vertex -0.95159 -19.4095 1.5
+      vertex -1.94454 -20.1945 0.5
+    endloop
+  endfacet
+  facet normal 0.321492 -0.53616 -0.780497
+    outer loop
+      vertex -1.29634 -15.8247 0.5
+      vertex -0.833355 -17.0028 1.5
+      vertex -1.52782 -15.9635 0.5
+    endloop
+  endfacet
+  facet normal -0.536237 0.321372 -0.780493
+    outer loop
+      vertex 2.42528 -19.5463 0.5
+      vertex 2.28654 -19.7778 0.5
+      vertex 1.2472 -19.0834 1.5
+    endloop
+  endfacet
+  facet normal -0.26715 0.565177 -0.780516
+    outer loop
+      vertex 0.707094 -19.5729 1.5
+      vertex 1.05238 -20.7907 0.5
+      vertex 0.574024 -19.6358 1.5
+    endloop
+  endfacet
+  facet normal 0.606419 -0.151883 -0.780505
+    outer loop
+      vertex -2.63159 -17.4517 0.5
+      vertex -1.43541 -17.8146 1.5
+      vertex -2.69716 -17.7135 0.5
+    endloop
+  endfacet
+  facet normal -0.0917319 0.618382 -0.780506
+    outer loop
+      vertex 0.536498 -20.9472 0.5
+      vertex 0.269547 -20.9868 0.5
+      vertex 0.147025 -19.7428 1.5
+    endloop
+  endfacet
+  facet normal -0.0917316 0.618382 -0.780506
+    outer loop
+      vertex 0.292635 -19.7212 1.5
+      vertex 0.536498 -20.9472 0.5
+      vertex 0.147025 -19.7428 1.5
+    endloop
+  endfacet
+  facet normal 0.618385 -0.0917384 -0.780503
+    outer loop
+      vertex -1.47118 -17.9574 1.5
+      vertex -1.49278 -18.103 1.5
+      vertex -2.69716 -17.7135 0.5
+    endloop
+  endfacet
+  facet normal -0.606419 -0.151883 -0.780505
+    outer loop
+      vertex 2.63159 -17.4517 0.5
+      vertex 2.69716 -17.7135 0.5
+      vertex 1.43541 -17.8146 1.5
+    endloop
+  endfacet
+  facet normal 0.606416 0.151901 -0.780503
+    outer loop
+      vertex -1.47118 -18.5426 1.5
+      vertex -1.43541 -18.6854 1.5
+      vertex -2.69716 -18.7865 0.5
+    endloop
+  endfacet
+  facet normal 0.588604 0.210609 -0.780506
+    outer loop
+      vertex -1.43541 -18.6854 1.5
+      vertex -2.54067 -19.3024 0.5
+      vertex -2.63159 -19.0483 0.5
+    endloop
+  endfacet
+  facet normal 0.565145 0.267244 -0.780507
+    outer loop
+      vertex -1.38582 -18.824 1.5
+      vertex -1.32288 -18.9571 1.5
+      vertex -2.54067 -19.3024 0.5
+    endloop
+  endfacet
+  facet normal -0.606416 0.151901 -0.780503
+    outer loop
+      vertex 1.47118 -18.5426 1.5
+      vertex 2.69716 -18.7865 0.5
+      vertex 1.43541 -18.6854 1.5
+    endloop
+  endfacet
+  facet normal -0.606416 -0.151901 -0.780503
+    outer loop
+      vertex 2.69716 -17.7135 0.5
+      vertex 1.47118 -17.9574 1.5
+      vertex 1.43541 -17.8146 1.5
+    endloop
+  endfacet
+  facet normal -0.41991 -0.463128 -0.780505
+    outer loop
+      vertex 1.74458 -16.1242 0.5
+      vertex 1.94454 -16.3055 0.5
+      vertex 0.95159 -17.0905 1.5
+    endloop
+  endfacet
+  facet normal -0.618391 -0.0917163 -0.780501
+    outer loop
+      vertex 2.69716 -17.7135 0.5
+      vertex 2.73676 -17.9805 0.5
+      vertex 1.49278 -18.103 1.5
+    endloop
+  endfacet
+  facet normal -0.321464 -0.536174 -0.780499
+    outer loop
+      vertex 1.29634 -15.8247 0.5
+      vertex 0.833355 -17.0028 1.5
+      vertex 0.707094 -16.9271 1.5
+    endloop
+  endfacet
+  facet normal 0.536257 -0.32133 -0.780497
+    outer loop
+      vertex -1.2472 -17.4166 1.5
+      vertex -1.32288 -17.5429 1.5
+      vertex -2.42528 -16.9537 0.5
+    endloop
+  endfacet
+  facet normal 0.624401 0.0306679 -0.780502
+    outer loop
+      vertex -1.5 -18.25 1.5
+      vertex -1.49278 -18.397 1.5
+      vertex -2.75 -18.25 0.5
+    endloop
+  endfacet
+  facet normal 0.210637 -0.588583 -0.780514
+    outer loop
+      vertex -0.435427 -16.8146 1.5
+      vertex -0.574024 -16.8642 1.5
+      vertex -1.05238 -15.7093 0.5
+    endloop
+  endfacet
+  facet normal 0.565106 0.267354 -0.780498
+    outer loop
+      vertex -1.32288 -18.9571 1.5
+      vertex -2.42528 -19.5463 0.5
+      vertex -2.54067 -19.3024 0.5
+    endloop
+  endfacet
+  facet normal -0.536257 0.32133 -0.780497
+    outer loop
+      vertex 1.32288 -18.9571 1.5
+      vertex 2.42528 -19.5463 0.5
+      vertex 1.2472 -19.0834 1.5
+    endloop
+  endfacet
+  facet normal -0.321492 0.53616 -0.780497
+    outer loop
+      vertex 1.52782 -20.5365 0.5
+      vertex 1.29634 -20.6753 0.5
+      vertex 0.833355 -19.4972 1.5
+    endloop
+  endfacet
+  facet normal -0.606419 0.151883 -0.780505
+    outer loop
+      vertex 2.69716 -18.7865 0.5
+      vertex 2.63159 -19.0483 0.5
+      vertex 1.43541 -18.6854 1.5
+    endloop
+  endfacet
+  facet normal 0.588604 -0.210609 -0.780506
+    outer loop
+      vertex -2.54067 -17.1976 0.5
+      vertex -1.43541 -17.8146 1.5
+      vertex -2.63159 -17.4517 0.5
+    endloop
+  endfacet
+  facet normal -0.565106 0.267354 -0.780498
+    outer loop
+      vertex 2.54067 -19.3024 0.5
+      vertex 2.42528 -19.5463 0.5
+      vertex 1.32288 -18.9571 1.5
+    endloop
+  endfacet
+  facet normal 0.0305777 0.624403 -0.780504
+    outer loop
+      vertex -0.147025 -19.7428 1.5
+      vertex 0 -21 0.5
+      vertex -0.269547 -20.9868 0.5
+    endloop
+  endfacet
+  facet normal 0.606416 -0.151901 -0.780503
+    outer loop
+      vertex -1.43541 -17.8146 1.5
+      vertex -1.47118 -17.9574 1.5
+      vertex -2.69716 -17.7135 0.5
+    endloop
+  endfacet
+  facet normal 0.26715 0.565177 -0.780516
+    outer loop
+      vertex -0.707094 -19.5729 1.5
+      vertex -0.574024 -19.6358 1.5
+      vertex -1.05238 -20.7907 0.5
+    endloop
+  endfacet
+  facet normal -0.152029 -0.606385 -0.780502
+    outer loop
+      vertex 0.536498 -15.5528 0.5
+      vertex 0.435427 -16.8146 1.5
+      vertex 0.292635 -16.7788 1.5
+    endloop
+  endfacet
+  facet normal -0.372311 -0.502191 -0.780506
+    outer loop
+      vertex 1.52782 -15.9635 0.5
+      vertex 1.74458 -16.1242 0.5
+      vertex 0.95159 -17.0905 1.5
+    endloop
+  endfacet
+  facet normal 0.536257 0.32133 -0.780497
+    outer loop
+      vertex -1.32288 -18.9571 1.5
+      vertex -1.2472 -19.0834 1.5
+      vertex -2.42528 -19.5463 0.5
+    endloop
+  endfacet
+  facet normal -0.21057 0.588615 -0.780508
+    outer loop
+      vertex 1.05238 -20.7907 0.5
+      vertex 0.798283 -20.8816 0.5
+      vertex 0.435427 -19.6854 1.5
+    endloop
+  endfacet
+  facet normal 0.37244 -0.502114 -0.780494
+    outer loop
+      vertex -0.833355 -17.0028 1.5
+      vertex -0.95159 -17.0905 1.5
+      vertex -1.52782 -15.9635 0.5
+    endloop
+  endfacet
+  facet normal -0.26715 -0.565177 -0.780516
+    outer loop
+      vertex 1.05238 -15.7093 0.5
+      vertex 0.707094 -16.9271 1.5
+      vertex 0.574024 -16.8642 1.5
+    endloop
+  endfacet
+  facet normal 0.0917319 -0.618382 -0.780506
+    outer loop
+      vertex -0.269547 -15.5132 0.5
+      vertex -0.147025 -16.7572 1.5
+      vertex -0.536498 -15.5528 0.5
+    endloop
+  endfacet
+  facet normal -0.502162 -0.37236 -0.780501
+    outer loop
+      vertex 2.12578 -16.5054 0.5
+      vertex 2.28654 -16.7222 0.5
+      vertex 1.15952 -17.2984 1.5
+    endloop
+  endfacet
+  facet normal -0.419716 -0.463344 -0.780481
+    outer loop
+      vertex 1.94454 -16.3055 0.5
+      vertex 1.06066 -17.1893 1.5
+      vertex 0.95159 -17.0905 1.5
+    endloop
+  endfacet
+  facet normal -0.267317 -0.565118 -0.780502
+    outer loop
+      vertex 1.05238 -15.7093 0.5
+      vertex 1.29634 -15.8247 0.5
+      vertex 0.707094 -16.9271 1.5
+    endloop
+  endfacet
+  facet normal -0.565106 -0.267354 -0.780498
+    outer loop
+      vertex 2.42528 -16.9537 0.5
+      vertex 2.54067 -17.1976 0.5
+      vertex 1.32288 -17.5429 1.5
+    endloop
+  endfacet
+  facet normal -0.151955 0.606396 -0.780509
+    outer loop
+      vertex 0.798283 -20.8816 0.5
+      vertex 0.536498 -20.9472 0.5
+      vertex 0.435427 -19.6854 1.5
+    endloop
+  endfacet
+  facet normal -0.41991 0.463128 -0.780505
+    outer loop
+      vertex 1.94454 -20.1945 0.5
+      vertex 1.74458 -20.3758 0.5
+      vertex 0.95159 -19.4095 1.5
+    endloop
+  endfacet
+  facet normal 0.37244 0.502114 -0.780494
+    outer loop
+      vertex -0.95159 -19.4095 1.5
+      vertex -0.833355 -19.4972 1.5
+      vertex -1.52782 -20.5365 0.5
+    endloop
+  endfacet
+  facet normal -0.624402 0.0306756 -0.780501
+    outer loop
+      vertex 2.75 -18.25 0.5
+      vertex 2.73676 -18.5195 0.5
+      vertex 1.49278 -18.397 1.5
+    endloop
+  endfacet
+  facet normal -0.624401 0.0306679 -0.780502
+    outer loop
+      vertex 1.5 -18.25 1.5
+      vertex 2.75 -18.25 0.5
+      vertex 1.49278 -18.397 1.5
+    endloop
+  endfacet
+  facet normal -0.502104 0.372458 -0.780491
+    outer loop
+      vertex 1.2472 -19.0834 1.5
+      vertex 2.28654 -19.7778 0.5
+      vertex 1.15952 -19.2016 1.5
+    endloop
+  endfacet
+  facet normal -0.0305778 -0.624403 -0.780504
+    outer loop
+      vertex 0 -15.5 0.5
+      vertex 0.147025 -16.7572 1.5
+      vertex 0 -16.75 1.5
+    endloop
+  endfacet
+  facet normal 0.372311 0.502191 -0.780506
+    outer loop
+      vertex -0.95159 -19.4095 1.5
+      vertex -1.52782 -20.5365 0.5
+      vertex -1.74458 -20.3758 0.5
+    endloop
+  endfacet
+  facet normal 0.41991 0.463128 -0.780505
+    outer loop
+      vertex -0.95159 -19.4095 1.5
+      vertex -1.74458 -20.3758 0.5
+      vertex -1.94454 -20.1945 0.5
+    endloop
+  endfacet
+  facet normal 0.210637 0.588583 -0.780514
+    outer loop
+      vertex -0.574024 -19.6358 1.5
+      vertex -0.435427 -19.6854 1.5
+      vertex -1.05238 -20.7907 0.5
+    endloop
+  endfacet
+  facet normal -0.372311 0.502191 -0.780506
+    outer loop
+      vertex 1.74458 -20.3758 0.5
+      vertex 1.52782 -20.5365 0.5
+      vertex 0.95159 -19.4095 1.5
+    endloop
+  endfacet
+  facet normal -0.419716 0.463344 -0.780481
+    outer loop
+      vertex 1.06066 -19.3107 1.5
+      vertex 1.94454 -20.1945 0.5
+      vertex 0.95159 -19.4095 1.5
+    endloop
+  endfacet
+  facet normal -0.502162 0.37236 -0.780501
+    outer loop
+      vertex 2.28654 -19.7778 0.5
+      vertex 2.12578 -19.9946 0.5
+      vertex 1.15952 -19.2016 1.5
+    endloop
+  endfacet
+  facet normal -0.46314 0.419907 -0.7805
+    outer loop
+      vertex 2.12578 -19.9946 0.5
+      vertex 1.94454 -20.1945 0.5
+      vertex 1.15952 -19.2016 1.5
+    endloop
+  endfacet
+  facet normal 0.536237 -0.321372 -0.780493
+    outer loop
+      vertex -2.28654 -16.7222 0.5
+      vertex -1.2472 -17.4166 1.5
+      vertex -2.42528 -16.9537 0.5
+    endloop
+  endfacet
+  facet normal -0.151955 -0.606396 -0.780509
+    outer loop
+      vertex 0.536498 -15.5528 0.5
+      vertex 0.798283 -15.6184 0.5
+      vertex 0.435427 -16.8146 1.5
+    endloop
+  endfacet
+  facet normal 0.588608 0.210599 -0.780505
+    outer loop
+      vertex -1.43541 -18.6854 1.5
+      vertex -1.38582 -18.824 1.5
+      vertex -2.54067 -19.3024 0.5
+    endloop
+  endfacet
+  facet normal -0.37244 -0.502114 -0.780494
+    outer loop
+      vertex 1.52782 -15.9635 0.5
+      vertex 0.95159 -17.0905 1.5
+      vertex 0.833355 -17.0028 1.5
+    endloop
+  endfacet
+  facet normal 0.624401 -0.0306679 -0.780502
+    outer loop
+      vertex -1.49278 -18.103 1.5
+      vertex -1.5 -18.25 1.5
+      vertex -2.75 -18.25 0.5
+    endloop
+  endfacet
+  facet normal -0.565145 0.267244 -0.780507
+    outer loop
+      vertex 1.38582 -18.824 1.5
+      vertex 2.54067 -19.3024 0.5
+      vertex 1.32288 -18.9571 1.5
+    endloop
+  endfacet
+  facet normal -0.502104 -0.372458 -0.780491
+    outer loop
+      vertex 2.28654 -16.7222 0.5
+      vertex 1.2472 -17.4166 1.5
+      vertex 1.15952 -17.2984 1.5
+    endloop
+  endfacet
+  facet normal 0.502104 -0.372458 -0.780491
+    outer loop
+      vertex -1.15952 -17.2984 1.5
+      vertex -1.2472 -17.4166 1.5
+      vertex -2.28654 -16.7222 0.5
+    endloop
+  endfacet
+  facet normal 0.463271 -0.419789 -0.780485
+    outer loop
+      vertex -1.06066 -17.1893 1.5
+      vertex -1.15952 -17.2984 1.5
+      vertex -1.94454 -16.3055 0.5
+    endloop
+  endfacet
+  facet normal -0.0305778 0.624403 -0.780504
+    outer loop
+      vertex 0 -19.75 1.5
+      vertex 0.147025 -19.7428 1.5
+      vertex 0 -21 0.5
+    endloop
+  endfacet
+  facet normal -0.588608 0.210599 -0.780505
+    outer loop
+      vertex 1.43541 -18.6854 1.5
+      vertex 2.54067 -19.3024 0.5
+      vertex 1.38582 -18.824 1.5
+    endloop
+  endfacet
+  facet normal -0.588604 0.210609 -0.780506
+    outer loop
+      vertex 2.63159 -19.0483 0.5
+      vertex 2.54067 -19.3024 0.5
+      vertex 1.43541 -18.6854 1.5
+    endloop
+  endfacet
+  facet normal 0.41991 -0.463128 -0.780505
+    outer loop
+      vertex -1.74458 -16.1242 0.5
+      vertex -0.95159 -17.0905 1.5
+      vertex -1.94454 -16.3055 0.5
+    endloop
+  endfacet
+  facet normal 0.46314 -0.419907 -0.7805
+    outer loop
+      vertex -1.94454 -16.3055 0.5
+      vertex -1.15952 -17.2984 1.5
+      vertex -2.12578 -16.5054 0.5
+    endloop
+  endfacet
+  facet normal 0.588608 -0.210599 -0.780505
+    outer loop
+      vertex -1.38582 -17.676 1.5
+      vertex -1.43541 -17.8146 1.5
+      vertex -2.54067 -17.1976 0.5
+    endloop
+  endfacet
+  facet normal 0.21057 -0.588615 -0.780508
+    outer loop
+      vertex -0.798283 -15.6184 0.5
+      vertex -0.435427 -16.8146 1.5
+      vertex -1.05238 -15.7093 0.5
+    endloop
+  endfacet
+  facet normal -0.321492 -0.53616 -0.780497
+    outer loop
+      vertex 1.29634 -15.8247 0.5
+      vertex 1.52782 -15.9635 0.5
+      vertex 0.833355 -17.0028 1.5
+    endloop
+  endfacet
+  facet normal -0.588608 -0.210599 -0.780505
+    outer loop
+      vertex 2.54067 -17.1976 0.5
+      vertex 1.43541 -17.8146 1.5
+      vertex 1.38582 -17.676 1.5
+    endloop
+  endfacet
+  facet normal 0.267317 -0.565118 -0.780502
+    outer loop
+      vertex -1.05238 -15.7093 0.5
+      vertex -0.707094 -16.9271 1.5
+      vertex -1.29634 -15.8247 0.5
+    endloop
+  endfacet
+  facet normal 0.419716 -0.463344 -0.780481
+    outer loop
+      vertex -0.95159 -17.0905 1.5
+      vertex -1.06066 -17.1893 1.5
+      vertex -1.94454 -16.3055 0.5
+    endloop
+  endfacet
+  facet normal -0.536237 -0.321372 -0.780493
+    outer loop
+      vertex 2.28654 -16.7222 0.5
+      vertex 2.42528 -16.9537 0.5
+      vertex 1.2472 -17.4166 1.5
+    endloop
+  endfacet
+  facet normal 0.536237 0.321372 -0.780493
+    outer loop
+      vertex -1.2472 -19.0834 1.5
+      vertex -2.28654 -19.7778 0.5
+      vertex -2.42528 -19.5463 0.5
+    endloop
+  endfacet
+  facet normal -0.0305777 -0.624403 -0.780504
+    outer loop
+      vertex 0.269547 -15.5132 0.5
+      vertex 0.147025 -16.7572 1.5
+      vertex 0 -15.5 0.5
+    endloop
+  endfacet
+  facet normal 0.618385 0.0917384 -0.780503
+    outer loop
+      vertex -1.49278 -18.397 1.5
+      vertex -1.47118 -18.5426 1.5
+      vertex -2.69716 -18.7865 0.5
+    endloop
+  endfacet
+  facet normal 0.46314 0.419907 -0.7805
+    outer loop
+      vertex -1.15952 -19.2016 1.5
+      vertex -1.94454 -20.1945 0.5
+      vertex -2.12578 -19.9946 0.5
+    endloop
+  endfacet
+  facet normal 0.502104 0.372458 -0.780491
+    outer loop
+      vertex -1.2472 -19.0834 1.5
+      vertex -1.15952 -19.2016 1.5
+      vertex -2.28654 -19.7778 0.5
+    endloop
+  endfacet
+  facet normal -0.37244 0.502114 -0.780494
+    outer loop
+      vertex 0.95159 -19.4095 1.5
+      vertex 1.52782 -20.5365 0.5
+      vertex 0.833355 -19.4972 1.5
+    endloop
+  endfacet
+  facet normal 0.0917319 0.618382 -0.780506
+    outer loop
+      vertex -0.147025 -19.7428 1.5
+      vertex -0.269547 -20.9868 0.5
+      vertex -0.536498 -20.9472 0.5
+    endloop
+  endfacet
+  facet normal 0.0305778 0.624403 -0.780504
+    outer loop
+      vertex 0 -19.75 1.5
+      vertex 0 -21 0.5
+      vertex -0.147025 -19.7428 1.5
+    endloop
+  endfacet
+  facet normal 0.152029 -0.606385 -0.780502
+    outer loop
+      vertex -0.292635 -16.7788 1.5
+      vertex -0.435427 -16.8146 1.5
+      vertex -0.536498 -15.5528 0.5
+    endloop
+  endfacet
+  facet normal 0.0917316 -0.618382 -0.780506
+    outer loop
+      vertex -0.147025 -16.7572 1.5
+      vertex -0.292635 -16.7788 1.5
+      vertex -0.536498 -15.5528 0.5
+    endloop
+  endfacet
+  facet normal 0.21057 0.588615 -0.780508
+    outer loop
+      vertex -0.435427 -19.6854 1.5
+      vertex -0.798283 -20.8816 0.5
+      vertex -1.05238 -20.7907 0.5
+    endloop
+  endfacet
+  facet normal 0.463271 0.419789 -0.780485
+    outer loop
+      vertex -1.15952 -19.2016 1.5
+      vertex -1.06066 -19.3107 1.5
+      vertex -1.94454 -20.1945 0.5
+    endloop
+  endfacet
+  facet normal -0.321464 0.536174 -0.780499
+    outer loop
+      vertex 0.833355 -19.4972 1.5
+      vertex 1.29634 -20.6753 0.5
+      vertex 0.707094 -19.5729 1.5
+    endloop
+  endfacet
+  facet normal -0.0917319 -0.618382 -0.780506
+    outer loop
+      vertex 0.269547 -15.5132 0.5
+      vertex 0.536498 -15.5528 0.5
+      vertex 0.147025 -16.7572 1.5
+    endloop
+  endfacet
+  facet normal 0.0305777 -0.624403 -0.780504
+    outer loop
+      vertex 0 -15.5 0.5
+      vertex -0.147025 -16.7572 1.5
+      vertex -0.269547 -15.5132 0.5
+    endloop
+  endfacet
+  facet normal -0.0917316 -0.618382 -0.780506
+    outer loop
+      vertex 0.536498 -15.5528 0.5
+      vertex 0.292635 -16.7788 1.5
+      vertex 0.147025 -16.7572 1.5
+    endloop
+  endfacet
+  facet normal 0.565145 -0.267244 -0.780507
+    outer loop
+      vertex -1.32288 -17.5429 1.5
+      vertex -1.38582 -17.676 1.5
+      vertex -2.54067 -17.1976 0.5
+    endloop
+  endfacet
+  facet normal 0.0917316 0.618382 -0.780506
+    outer loop
+      vertex -0.292635 -19.7212 1.5
+      vertex -0.147025 -19.7428 1.5
+      vertex -0.536498 -20.9472 0.5
+    endloop
+  endfacet
+  facet normal 0.618391 -0.0917163 -0.780501
+    outer loop
+      vertex -2.69716 -17.7135 0.5
+      vertex -1.49278 -18.103 1.5
+      vertex -2.73676 -17.9805 0.5
+    endloop
+  endfacet
+  facet normal 0.372311 -0.502191 -0.780506
+    outer loop
+      vertex -1.52782 -15.9635 0.5
+      vertex -0.95159 -17.0905 1.5
+      vertex -1.74458 -16.1242 0.5
+    endloop
+  endfacet
+  facet normal -0.618385 0.0917384 -0.780503
+    outer loop
+      vertex 1.49278 -18.397 1.5
+      vertex 2.69716 -18.7865 0.5
+      vertex 1.47118 -18.5426 1.5
+    endloop
+  endfacet
+  facet normal 0.151955 0.606396 -0.780509
+    outer loop
+      vertex -0.435427 -19.6854 1.5
+      vertex -0.536498 -20.9472 0.5
+      vertex -0.798283 -20.8816 0.5
+    endloop
+  endfacet
+  facet normal 0.321492 0.53616 -0.780497
+    outer loop
+      vertex -0.833355 -19.4972 1.5
+      vertex -1.29634 -20.6753 0.5
+      vertex -1.52782 -20.5365 0.5
+    endloop
+  endfacet
+  facet normal 0.152029 0.606385 -0.780502
+    outer loop
+      vertex -0.435427 -19.6854 1.5
+      vertex -0.292635 -19.7212 1.5
+      vertex -0.536498 -20.9472 0.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 12.5 -22.75 0
+      vertex 11.4 -22.75 1.5
+      vertex 12.5 -22.75 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 12.5 -22.75 0
+      vertex 11.4 -22.75 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 11.4 -22.75 1.5
+      vertex 11.4 -20.5 0
+      vertex 11.4 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.4 -20.5 0
+      vertex 11.4 -22.75 1.5
+      vertex 11.4 -22.75 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 11.4 -20.5 0
+      vertex 10.9 -20.5 1.5
+      vertex 11.4 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10.9 -20.5 1.5
+      vertex 11.4 -20.5 0
+      vertex 10.9 -20.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10.9 -20.5 1.5
+      vertex 10.9 -2.5 0
+      vertex 10.9 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10.9 -2.5 0
+      vertex 10.9 -20.5 1.5
+      vertex 10.9 -20.5 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.9 -2.5 0
+      vertex 11.4 -2.5 1.5
+      vertex 10.9 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.4 -2.5 1.5
+      vertex 10.9 -2.5 0
+      vertex 11.4 -2.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 11.4 -2.5 1.5
+      vertex 11.4 2.5 0
+      vertex 11.4 2.5 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.4 2.5 0
+      vertex 11.4 -2.5 1.5
+      vertex 11.4 -2.5 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 11.4 2.5 0
+      vertex 10.9 2.5 1.5
+      vertex 11.4 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 11.4 2.5 0
+      vertex 10.9 2.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10.9 2.5 1.5
+      vertex 10.9 20.5 0
+      vertex 10.9 20.5 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10.9 20.5 0
+      vertex 10.9 2.5 1.5
+      vertex 10.9 2.5 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.9 20.5 0
+      vertex 11.4 20.5 1.5
+      vertex 10.9 20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.4 20.5 1.5
+      vertex 10.9 20.5 0
+      vertex 11.4 20.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 11.4 20.5 1.5
+      vertex 11.4 25.5 0
+      vertex 11.4 25.5 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.4 25.5 0
+      vertex 11.4 20.5 1.5
+      vertex 11.4 20.5 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 11.4 25.5 0
+      vertex 10.9 25.5 1.5
+      vertex 11.4 25.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 11.4 25.5 0
+      vertex 10.9 25.5 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10.9 25.5 1.5
+      vertex 10.9 34.75 0
+      vertex 10.9 34.75 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10.9 34.75 0
+      vertex 10.9 25.5 1.5
+      vertex 10.9 25.5 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 10.9 34.75 0
+      vertex -10.9 34.75 1.5
+      vertex 10.9 34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.9 34.75 1.5
+      vertex 10.9 34.75 0
+      vertex -10.9 34.75 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -10.9 34.75 1.5
+      vertex -10.9 34.75 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -10.9 34.75 1.5
+      vertex -10.9 25.5 0
+      vertex -10.9 25.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.9 25.5 0
+      vertex -11.4 25.5 1.5
+      vertex -10.9 25.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.4 25.5 1.5
+      vertex -10.9 25.5 0
+      vertex -11.4 25.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -11.4 20.5 0
+      vertex -11.4 25.5 1.5
+      vertex -11.4 25.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -11.4 25.5 1.5
+      vertex -11.4 20.5 0
+      vertex -11.4 20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -11.4 20.5 0
+      vertex -10.9 20.5 1.5
+      vertex -11.4 20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -11.4 20.5 0
+      vertex -10.9 20.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -10.9 2.5 0
+      vertex -10.9 20.5 1.5
+      vertex -10.9 20.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -10.9 20.5 1.5
+      vertex -10.9 2.5 0
+      vertex -10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.9 2.5 0
+      vertex -11.4 2.5 1.5
+      vertex -10.9 2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.4 2.5 1.5
+      vertex -10.9 2.5 0
+      vertex -11.4 2.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -11.4 -2.5 0
+      vertex -11.4 2.5 1.5
+      vertex -11.4 2.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -11.4 2.5 1.5
+      vertex -11.4 -2.5 0
+      vertex -11.4 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -11.4 -2.5 0
+      vertex -10.9 -2.5 1.5
+      vertex -11.4 -2.5 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -10.9 -2.5 1.5
+      vertex -11.4 -2.5 0
+      vertex -10.9 -2.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -10.9 -2.5 1.5
+      vertex -10.9 -2.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -10.9 -2.5 1.5
+      vertex -10.9 -20.5 0
+      vertex -10.9 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.9 -20.5 0
+      vertex -11.4 -20.5 1.5
+      vertex -10.9 -20.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.4 -20.5 1.5
+      vertex -10.9 -20.5 0
+      vertex -11.4 -20.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -11.4 -22.75 0
+      vertex -11.4 -20.5 1.5
+      vertex -11.4 -20.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -11.4 -20.5 1.5
+      vertex -11.4 -22.75 0
+      vertex -11.4 -22.75 1.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.4 -22.75 0
+      vertex -12.5 -22.75 1.5
+      vertex -11.4 -22.75 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.5 -22.75 1.5
+      vertex -11.4 -22.75 0
+      vertex -12.5 -22.75 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -12.5 -34.75 0
+      vertex -12.5 -22.75 1.5
+      vertex -12.5 -22.75 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -12.5 -22.75 1.5
+      vertex -12.5 -34.75 0
+      vertex -12.5 -34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12.5 -34.75 0
+      vertex 12.5 -34.75 1.5
+      vertex -12.5 -34.75 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 12.5 -34.75 1.5
+      vertex -12.5 -34.75 0
+      vertex 12.5 -34.75 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 12.5 -34.75 1.5
+      vertex 12.5 -22.75 0
+      vertex 12.5 -22.75 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 12.5 -22.75 0
+      vertex 12.5 -34.75 1.5
+      vertex 12.5 -34.75 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- model Tuya tall sensor backplate in OpenSCAD with guides, wide base and countersunk screw holes
- export corresponding STL for printing

## Testing
- `openscad -o tuya-tall-sensor-backplate.stl tuya-tall-sensor-backplate.scad`


------
https://chatgpt.com/codex/tasks/task_e_68baf71c2ec0832b92a916edd700f139