### PR TITLE
Restore guide tabs on backplate

### DIFF
--- a/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad
+++ b/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad
@@ -12,9 +12,10 @@ wide_width  = 25;
 wide_height = 12;
 
 // Small side tabs used as guides
-// Each tab extends from one edge to the midpoint of the plate
-// at three locations along its height
-tab_width  = plate_width / 2;
+// These expand the width by 0.5 mm on each side (22.8 mm total)
+// at three locations along the height of the plate
+tab_extension = 0.5;                    // how far each tab extends beyond the plate
+tab_width  = plate_width + tab_extension * 2;
 tab_height = 5;
 // y positions for the centre of each tab relative to the
 // centre of the plate (positive is up)
@@ -41,10 +42,8 @@ module backplate2d() {
         translate([0, -plate_height/2 + wide_height/2])
             square([wide_width, wide_height], center=true);
         // guiding tabs
-        // positioned so that they start from the right edge and
-        // extend halfway across the plate
         for (y = tab_positions)
-            translate([plate_width/2 - tab_width/2, y])
+            translate([0, y])
                 square([tab_width, tab_height], center=true);
     }
 }


### PR DESCRIPTION
## Summary
- Reinstate side guide tabs on the tall sensor backplate
- Add `tab_extension` parameter and compute tab width from plate width

## Testing
- `openscad -o /tmp/test.stl tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad`


------
https://chatgpt.com/codex/tasks/task_e_68bafde62c58832b8013fe5518828fc5