### PR TITLE
Square two corners on Tuya tall sensor backplate

### DIFF
--- a/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad
+++ b/tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad
@@ -51,10 +51,21 @@ module tabs2d() {
 }
 
 // Apply rounding to the outer corners of the main plate
+// except for the top-left and bottom-right corners which remain square
 module rounded_backplate2d() {
-    offset(r = corner_radius)
-        offset(delta = -corner_radius)
-            backplate2d();
+    union() {
+        offset(r = corner_radius)
+            offset(delta = -corner_radius)
+                backplate2d();
+
+        // Restore square corner at top-left of the narrow section
+        translate([-plate_width/2, plate_height/2 - corner_radius])
+            square([corner_radius, corner_radius]);
+
+        // Restore square corner at bottom-right of the wide section
+        translate([wide_width/2 - corner_radius, -plate_height/2])
+            square([corner_radius, corner_radius]);
+    }
 }
 
 // Rounded profiles for tabs


### PR DESCRIPTION
## Summary
- Keep top-left and bottom-right corners sharp on the backplate

## Testing
- `openscad -o /tmp/backplate.stl tuya-tall-sensor-backplate/tuya-tall-sensor-backplate.scad`


------
https://chatgpt.com/codex/tasks/task_e_68bb801bfaf0832ba4581a5689d4c144