### PR TITLE
Add circular ridge with recessed center

### DIFF
--- a/possingham/square-thing.scad
+++ b/possingham/square-thing.scad
@@ -61,9 +61,22 @@ module bottom_left_ridge() {
         cube([bl_ridge_size[0], bl_ridge_size[1], plate_thickness], center=false);
 }
 
+// Circular ridge with recessed centre
+module circle_ridge() {
+    translate([plate_width/2, circle_center_y, 0])
+        difference() {
+            // outer ring at full height
+            cylinder(h = plate_thickness, d = circle_d, center=false);
+            // recessed centre leaving a ridge equal to "ridge"
+            translate([0, 0, plate_thickness - inset_depth])
+                cylinder(h = inset_depth, d = circle_d - 2*ridge, center=false);
+        }
+}
+
 union() {
     base_plate();
     right_ridge();
     bottom_left_ridge();
+    circle_ridge();
     posts();
 }


### PR DESCRIPTION
## Summary
- Add circle_ridge module with recessed center to provide ring feature
- Include circle ridge in overall union build

## Testing
- `openscad -o /tmp/square-thing.stl possingham/square-thing.scad`

------
https://chatgpt.com/codex/tasks/task_e_68bbd1ce8348832bbff9ca3efe9629b4